### PR TITLE
Switch to Material Symbols icons

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,7 +11,9 @@ interface NavItemProps {
 
 const NavItem: React.FC<NavItemProps> = ({ icon, label, isActive, badge, onClick }) => (
   <div onClick={onClick} className={`sidebar-nav-item${isActive ? " active" : ""}`}>
-    <div className="sidebar-nav-icon">{icon}</div>
+    <div className="sidebar-nav-icon">
+      <span className={`icon${isActive ? ' icon-active' : ''}`}>{icon}</span>
+    </div>
     <span>{label}</span>
     {badge && (
       <span className={`sidebar-badge ${badge === "Pro" ? "pro" : "count"}`}>{badge}</span>
@@ -34,15 +36,15 @@ export const Layout: React.FC<LayoutProps> = ({
   const [mobileOpen, setMobileOpen] = useState(false);
 
   const tabs = [
-    { id: "conversor", icon: "📂", label: "Conversor" },
-    { id: "formatos", icon: "📑", label: "Formatos", badge: "45+" },
-    { id: "historial", icon: "🕑", label: "Historial", badge: 12 },
-    { id: "creditos", icon: "💳", label: "Créditos" },
-    { id: "planes", icon: "💡", label: "Planes", badge: "Pro" },
-    { id: "faq", icon: "❔", label: "FAQ" },
-    { id: "valoraciones", icon: "⭐", label: "Valoraciones" },
-    { id: "configuracion", icon: "⚙️", label: "Configuración" },
-    { id: "estadisticas", icon: "📊", label: "Estadísticas" },
+    { id: "conversor", icon: "folder", label: "Conversor" },
+    { id: "formatos", icon: "description", label: "Formatos", badge: "45+" },
+    { id: "historial", icon: "history", label: "Historial", badge: 12 },
+    { id: "creditos", icon: "credit_card", label: "Créditos" },
+    { id: "planes", icon: "lightbulb", label: "Planes", badge: "Pro" },
+    { id: "faq", icon: "help", label: "FAQ" },
+    { id: "valoraciones", icon: "star", label: "Valoraciones" },
+    { id: "configuracion", icon: "settings", label: "Configuración" },
+    { id: "estadisticas", icon: "bar_chart", label: "Estadísticas" },
   ];
 
   return (
@@ -84,7 +86,9 @@ export const Layout: React.FC<LayoutProps> = ({
         <div className="fixed inset-0 z-50 flex md:hidden">
           <div className="absolute inset-0 bg-black/60" onClick={() => setMobileOpen(false)} />
           <aside className="relative w-64 bg-gray-800 flex flex-col">
-            <button className="self-end m-4" onClick={() => setMobileOpen(false)}>✕</button>
+            <button className="self-end m-4" onClick={() => setMobileOpen(false)}>
+              <span className="icon">close</span>
+            </button>
             <nav className="flex-1 overflow-y-auto py-4 px-3 space-y-1">
               {tabs.map((tab) => (
                 <NavItem
@@ -108,11 +112,11 @@ export const Layout: React.FC<LayoutProps> = ({
       <div className="flex-1 flex flex-col overflow-hidden">
         <header className="flex items-center justify-end md:justify-end p-3 bg-gray-800 border-b border-gray-700/50">
           <button className="md:hidden mr-auto" onClick={() => setMobileOpen(true)} aria-label="Abrir menú">
-            ☰
+            <span className="icon">menu</span>
           </button>
           <div className="flex items-center space-x-3">
             <div className="flex items-center text-sm font-semibold bg-gray-700/50 px-3 py-1.5 rounded-lg">
-              <span className="text-primary mr-2">💎</span>
+              <span className="icon icon-active mr-2">diamond</span>
               <span>{user?.credits || 50} créditos</span>
             </div>
             <div className="relative">
@@ -120,7 +124,7 @@ export const Layout: React.FC<LayoutProps> = ({
                 className="w-8 h-8 bg-gradient-to-r from-primary to-secondary rounded-full flex items-center justify-center text-white font-bold"
                 aria-label="Menú de usuario"
               >
-                👤
+                <span className="icon">person</span>
               </button>
               <span className="absolute -bottom-1 -right-1 w-3 h-3 bg-success rounded-full border-2 border-gray-800" />
             </div>

--- a/frontend/src/components/UniversalConverter.tsx
+++ b/frontend/src/components/UniversalConverter.tsx
@@ -27,7 +27,7 @@ const ConversionStep: React.FC<{
 
 // Componente de tarjeta de conversión
 const ConversionCard: React.FC<{
-  icon: React.ReactNode;
+  icon: string;
   title: string;
   children: React.ReactNode;
   isActive: boolean;
@@ -37,7 +37,9 @@ const ConversionCard: React.FC<{
     isActive ? 'border-2 border-primary shadow-lg' : 'border border-gray-700/50'
   }`}>
     <div className="flex items-center mb-3">
-      <div className="text-3xl mr-3">{icon}</div>
+      <div className="text-3xl mr-3">
+        <span className="icon icon-lg">{icon}</span>
+      </div>
       <h3 className="text-xl font-semibold">{title}</h3>
       {isCompleted && (
         <div className="ml-auto bg-success/20 text-success text-xs font-semibold px-2 py-1 rounded-full">
@@ -62,7 +64,9 @@ const PopularConversion: React.FC<{
     onClick={onClick}
   >
     <div className="flex items-center justify-between">
-      <div className="text-3xl mr-3">{icon}</div>
+      <div className="text-3xl mr-3">
+        <span className="icon icon-lg">{icon}</span>
+      </div>
       <div className="flex-1">
         <h4 className="font-medium">{from} → {to}</h4>
         <p className="text-xs text-gray-400">{cost} créditos</p>
@@ -82,11 +86,11 @@ export const UniversalConverter: React.FC = () => {
 
   // Memoized popular conversions
   const popularConversions = useMemo(() => [
-    { from: 'PDF', to: 'JPG', icon: '📄 → 🖼️', cost: 2 },
-    { from: 'JPG', to: 'PNG', icon: '🖼️ → 🎨', cost: 1 },
-    { from: 'MP4', to: 'GIF', icon: '🎬 → 🎞️', cost: 5 },
-    { from: 'PNG', to: 'SVG', icon: '🖼️ → 📐', cost: 3 },
-    { from: 'DOC', to: 'PDF', icon: '📝 → 📄', cost: 2 },
+    { from: 'PDF', to: 'JPG', icon: 'swap_horiz', cost: 2 },
+    { from: 'JPG', to: 'PNG', icon: 'swap_horiz', cost: 1 },
+    { from: 'MP4', to: 'GIF', icon: 'swap_horiz', cost: 5 },
+    { from: 'PNG', to: 'SVG', icon: 'swap_horiz', cost: 3 },
+    { from: 'DOC', to: 'PDF', icon: 'swap_horiz', cost: 2 },
   ], []);
 
   // Optimized file selection handler
@@ -136,7 +140,9 @@ export const UniversalConverter: React.FC = () => {
       {/* Encabezado */}
       <div className="text-center mb-8">
         <div className="flex items-center justify-center mb-2">
-          <div className="text-3xl mr-3">🎯</div>
+          <div className="text-3xl mr-3">
+            <span className="icon icon-lg">target</span>
+          </div>
           <h1 className="text-3xl font-bold">Conversor Inteligente</h1>
         </div>
         <p className="text-gray-300">Convierte archivos con inteligencia artificial avanzada</p>
@@ -153,9 +159,9 @@ export const UniversalConverter: React.FC = () => {
       {/* Tarjetas de conversión */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         {/* Paso 1: Subir Archivo */}
-        <ConversionCard 
-          icon="📂" 
-          title="Subir Archivo" 
+        <ConversionCard
+          icon="upload"
+          title="Subir Archivo"
           isActive={currentStep === 1}
           isCompleted={currentStep > 1}
         >
@@ -186,9 +192,9 @@ export const UniversalConverter: React.FC = () => {
         </ConversionCard>
 
         {/* Paso 2: Análisis IA */}
-        <ConversionCard 
-          icon="🤖" 
-          title="Análisis IA" 
+        <ConversionCard
+          icon="smart_toy"
+          title="Análisis IA"
           isActive={currentStep === 2}
           isCompleted={currentStep > 2}
         >
@@ -212,9 +218,9 @@ export const UniversalConverter: React.FC = () => {
         </ConversionCard>
 
         {/* Paso 3: Configurar */}
-        <ConversionCard 
-          icon="⚙️" 
-          title="Configurar" 
+        <ConversionCard
+          icon="settings"
+          title="Configurar"
           isActive={currentStep === 3}
           isCompleted={currentStep > 3}
         >
@@ -254,9 +260,9 @@ export const UniversalConverter: React.FC = () => {
         </ConversionCard>
 
         {/* Paso 4: Descargar */}
-        <ConversionCard 
-          icon="⬇️" 
-          title="Descargar" 
+        <ConversionCard
+          icon="download"
+          title="Descargar"
           isActive={currentStep === 4}
           isCompleted={currentStep > 4}
         >
@@ -269,7 +275,7 @@ export const UniversalConverter: React.FC = () => {
             ) : (
               <div className="text-center">
                 <div className="mb-2">
-                  <span className="text-3xl">🎉</span>
+                  <span className="icon icon-lg">celebration</span>
                 </div>
                 <button className="bg-success hover:bg-success/80 text-white py-2 px-4 rounded-md transition-colors">
                   Descargar Archivo
@@ -290,7 +296,7 @@ export const UniversalConverter: React.FC = () => {
       {/* Conversiones Populares */}
       <div className="mt-12">
         <h2 className="text-2xl font-bold mb-4 flex items-center">
-          <span className="text-2xl mr-2">🚀</span>
+          <span className="icon icon-lg mr-2">rocket_launch</span>
           Conversiones Populares
         </h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">

--- a/frontend/src/styles/brand-styles.css
+++ b/frontend/src/styles/brand-styles.css
@@ -1,5 +1,6 @@
 /* frontend/src/styles/variables.css */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded');
 
 :root {
   /* Colores primarios */
@@ -427,4 +428,19 @@ body {
 
 .animate-pulse {
   animation: pulse 1.5s infinite;
+}
+
+/* Icon helpers */
+.icon {
+  font-family: 'Material Symbols Rounded';
+  font-variation-settings: 'FILL' 0, 'wght' 400;
+  font-size: 24px;
+}
+
+.icon-lg {
+  font-size: 32px;
+}
+
+.icon-active {
+  color: var(--color-primary);
 }


### PR DESCRIPTION
## Summary
- import Material Symbols Rounded font in brand styles
- add helper icon classes
- replace emoji icons in layout and universal converter with Material Symbols

## Testing
- `npm test` *(fails: repeated proxy warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688245c8677c832093f906a3a7ad49c2