### PR TITLE
Remove CDN Tailwind and compile during build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "concurrently \"next dev\" \"open-cli http://localhost:3000\"",
-    "build": "next build",
+    "build:css": "tailwindcss -i ./src/index.css -o ./public/index.css",
+    "build": "npm run build:css && next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Universal File Converter</title>
-    <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.6.0/mammoth.browser.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/2.1.0/showdown.min.js"></script>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 @import url('https://fonts.apple.com/sf-pro-display.css');
 :root {
   --color-primary: #006EE6;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,9 @@
 // tailwind.config.js
 module.exports = {
+  content: [
+    './public/**/*.html',
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- remove external Tailwind script from `index.html`
- add Tailwind directives to `src/index.css`
- configure `tailwind.config.js` with content paths
- compile Tailwind CSS as part of `npm run build`

## Testing
- `npm run build:css` *(fails: tailwindcss not found until dependencies installed)*
- `npm test` *(fails: repeated `http-proxy` warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688245d6d6f48320981c1877bbf27061