### PR TITLE
Add gradient styling to layout components

### DIFF
--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -11,7 +11,8 @@ export const Header: React.FC<HeaderProps> = ({ sidebarCollapsed }) => {
 
   return (
     <header className={`
-      fixed top-0 right-0 h-16 bg-slate-900/95 backdrop-blur-sm border-b border-slate-700/50
+      fixed top-0 right-0 h-16 bg-gradient-to-br from-primary to-secondary
+      backdrop-blur-sm border-b border-slate-700/50 shadow-lg rounded-lg
       transition-all duration-300 ease-in-out z-30
       ${sidebarCollapsed ? 'left-16' : 'left-72'}
     `}>

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -35,7 +35,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
 }) => {
   return (
     <div className={`
-      fixed left-0 top-0 h-full bg-slate-900/95 backdrop-blur-sm border-r border-slate-700/50
+      fixed left-0 top-0 h-full bg-gradient-to-br from-primary to-secondary
+      backdrop-blur-sm border-r border-slate-700/50 shadow-lg rounded-lg
       transition-all duration-300 ease-in-out z-40
       ${isCollapsed ? 'w-16' : 'w-72'}
     `}>
@@ -43,7 +44,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
       <div className="flex items-center justify-between p-4 border-b border-slate-700/50">
         {!isCollapsed && (
           <div className="flex items-center">
-            <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center text-white font-bold text-sm">
+            <div className="w-8 h-8 bg-gradient-to-br from-primary to-secondary rounded-lg flex items-center justify-center text-white font-bold text-sm">
               A
             </div>
             <div className="ml-3">

--- a/frontend/src/components/NewConversorInteligente.tsx
+++ b/frontend/src/components/NewConversorInteligente.tsx
@@ -19,11 +19,11 @@ const ConversionStep: React.FC<ConversionStepProps> = ({
   children
 }) => (
   <div className={`
-    bg-slate-800/40 backdrop-blur-sm rounded-xl border transition-all duration-300
-    ${isActive 
-      ? 'border-primary shadow-lg shadow-primary/20 scale-105' 
-      : isCompleted 
-        ? 'border-green-500/50 shadow-lg shadow-green-500/10'
+    bg-gradient-to-br from-primary/10 to-secondary/10 backdrop-blur-sm rounded-lg border shadow-lg transition-all duration-300
+    ${isActive
+      ? 'border-primary shadow-primary/20 scale-105'
+      : isCompleted
+        ? 'border-green-500/50 shadow-green-500/10'
         : 'border-slate-700/50 hover:border-slate-600/50'
     }
   `}>


### PR DESCRIPTION
## Summary
- update `Header` with gradient background and shadow
- apply gradient treatment to `Sidebar` and logo block
- restyle `ConversionStep` cards with gradient and consistent rounding

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6882986ea4ec8320959e262de2af6cd8