### PR TITLE
Consolidate brand CSS variables

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,16 +1,3 @@
-
-@import url('https://fonts.apple.com/sf-pro-display.css');
-:root {
-  --color-primary: #006EE6;
-  --color-secondary: #00B8D9;
-  --color-success: #28A745;
-  --color-warning: #FFC107;
-  --color-danger: #DC3545;
-  --color-neutral-100: #FFFFFF;
-  --color-neutral-200: #F5F5F5;
-  --color-neutral-900: #0D0D0D;
-  --font-heading: 'SF Pro Display', -apple-system, sans-serif;
-}
 .button-primary {
   background: var(--color-primary);
   color: var(--color-neutral-100);

--- a/frontend/src/styles/brand-styles.css
+++ b/frontend/src/styles/brand-styles.css
@@ -29,6 +29,9 @@
   --color-gray-400: #8492A6;
   --color-gray-700: #3E4C59;
   --color-gray-900: #1F2933;
+  --color-neutral-100: #FFFFFF;
+  --color-neutral-200: #F5F5F5;
+  --color-neutral-900: #0D0D0D;
   
   /* Tamaños de fuente - Escritorio */
   --font-size-h1: 2rem;        /* 32px */
@@ -61,9 +64,10 @@
   --space-6: 32px;
   --space-7: 48px;
   --space-8: 64px;
-  
+
   /* Fuente principal */
   --font-primary: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  --font-heading: 'SF Pro Display', -apple-system, sans-serif;
 }
 
 /* Media query para móviles */
@@ -436,19 +440,7 @@ body {
   animation: pulse 1.5s infinite;
 }
 
-@import url('https://fonts.apple.com/sf-pro-display.css');
 
-:root {
-  --color-primary: #006EE6;
-  --color-secondary: #00B8D9;
-  --color-success: #28A745;
-  --color-warning: #FFC107;
-  --color-danger: #DC3545;
-  --color-neutral-100: #FFFFFF;
-  --color-neutral-200: #F5F5F5;
-  --color-neutral-900: #0D0D0D;
-  --font-heading: 'SF Pro Display', -apple-system, sans-serif;
-}
 
 .button-primary {
   background: var(--color-primary);


### PR DESCRIPTION
## Summary
- merge color variables into `brand-styles.css`
- drop apple font import from CSS files and keep Inter
- keep `_app.tsx` referencing the consolidated stylesheet

## Testing
- `npm test` *(fails: recurses to itself)*

------
https://chatgpt.com/codex/tasks/task_e_688298550bac8320ade1f5ad6d24dc26