### PR TITLE
Remove duplicate User interfaces

### DIFF
--- a/docs/assets/search_images/api.ts
+++ b/docs/assets/search_images/api.ts
@@ -2,26 +2,7 @@
 const API_BASE_URL = 'http://localhost:8000/api';
 
 // Tipos de datos
-export interface User {
-  id: number;
-  email: string;
-  full_name: string;
-  plan: string;
-  credits: number;
-  total_conversions: number;
-  credits_used_today: number;
-  credits_used_this_month: number;
-  created_at: string;
-  last_login: string | null;
-  is_active: boolean;
-  plan_info: {
-    name: string;
-    monthly_credits: number;
-    daily_limit: number;
-    features: string[];
-    price?: number;
-  };
-}
+import type { User } from '../../../frontend/src/types/User';
 
 export interface LoginResponse {
   message: string;

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,12 +1,7 @@
 // frontend/src/auth/AuthContext.tsx
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { apiService, User, LoginData, RegisterData } from '../services/api';
-
-export interface User {
-  name: string;
-  email: string;
-  // Puedes añadir más campos si lo necesitas, como `id`, `avatar`, etc.
-}
+import { apiService, LoginData, RegisterData } from '../services/api';
+import type { User } from '../types/User';
 
 interface AuthContextType {
   user: User | null;

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -1,11 +1,7 @@
 // frontend/src/components/Layout/Header.tsx
 import React from 'react';
 import { useAuth } from '../../auth/AuthContext';
-
-interface User {
-  name?: string;
-  email?: string;
-}
+import type { User } from '../../types/User';
 
 interface HeaderProps {
   sidebarCollapsed: boolean;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,25 +1,5 @@
 // --- TIPOS DE DATOS (Interfaces) ---
-// Esta interfaz 'User' está actualizada para coincidir con lo que el backend devuelve
-export interface User {
-  id: number;
-  full_name: string;
-  email: string;
-  credits: number;
-  plan: string;
-  plan_info: {
-    name: string;
-    monthly_credits?: number;
-    daily_limit?: number;
-    price?: number;
-    features?: string[];
-  };
-  total_conversions: number;
-  credits_used_today: number;
-  credits_used_this_month: number;
-  created_at: string | null;
-  last_login: string | null;
-  is_active: boolean;
-}
+import type { User } from '../types/User';
 
 export interface LoginData {
   email: string;


### PR DESCRIPTION
## Summary
- centralize the `User` interface in `src/types/User.ts`
- refactor AuthContext, api service, Header and docs to import the shared type
- run `npm run lint` (fails because ESLint isn't configured)

## Testing
- `CI=true npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688310979bdc8320bf0e8d9dc8b1c121