### PR TITLE
Align components with brand styles

### DIFF
--- a/frontend/src/components/ConversionSuccess.tsx
+++ b/frontend/src/components/ConversionSuccess.tsx
@@ -33,35 +33,37 @@ export const ConversionSuccess: React.FC<ConversionSuccessProps> = ({ fromFile, 
 
   return (
     <div className="flex flex-col items-center text-center space-y-6">
-      <div className="flex items-center justify-center w-16 h-16 bg-green-100 rounded-full">
-        <IconCheck className="w-10 h-10 text-green-600" />
+      <div className="flex items-center justify-center w-16 h-16 rounded-full bg-green-100">
+        <IconCheck className="w-10 h-10 text-success" />
       </div>
       <div>
-        <h2 className="text-2xl font-bold text-slate-800">Conversion Complete!</h2>
-        <p className="text-slate-500 mt-1">
-          Your file <span className="font-semibold text-slate-700">{fromFile}</span> has been converted to <span className="font-semibold text-slate-700">{toFormat}</span>.
+        <h2 className="text-h2 text-success">¡Conversión completada!</h2>
+        <p className="text-body mt-1">
+          Tu archivo <span className="font-semibold">{fromFile}</span> se convirtió a <span className="font-semibold text-primary">{toFormat}</span>.
         </p>
       </div>
 
-      <div className="w-full max-w-md bg-slate-50 border rounded-lg p-4">
-        <p className="font-mono text-slate-800 break-all">{getNewFileName()}</p>
+      <div className="card w-full max-w-md">
+        <div className="card-body">
+          <p className="font-mono break-all">{getNewFileName()}</p>
+        </div>
       </div>
-      
+
       <div className="w-full flex flex-col sm:flex-row sm:justify-center items-center space-y-4 sm:space-y-0 sm:space-x-4 pt-4">
         <button
-            onClick={onReset}
-            className="w-full sm:w-auto order-2 sm:order-1 flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-slate-700 bg-slate-200 hover:bg-slate-300 transition-colors"
-          >
-            <IconRefresh className="w-5 h-5 mr-2" />
-            Convert Another
-          </button>
-          <button
-            onClick={handleDownload}
-            className="w-full sm:w-auto order-1 sm:order-2 flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
-          >
-            <IconDownload className="w-5 h-5 mr-2" />
-            Download File
-          </button>
+          onClick={onReset}
+          className="btn btn-secondary w-full sm:w-auto order-2 sm:order-1 flex items-center justify-center"
+        >
+          <IconRefresh className="w-5 h-5 mr-2" />
+          Convertir otro
+        </button>
+        <button
+          onClick={handleDownload}
+          className="btn btn-primary w-full sm:w-auto order-1 sm:order-2 flex items-center justify-center"
+        >
+          <IconDownload className="w-5 h-5 mr-2" />
+          Descargar archivo
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/CreditPurchase.tsx
+++ b/frontend/src/components/CreditPurchase.tsx
@@ -94,7 +94,7 @@ export const CreditPurchase: React.FC = () => {
     <div className="space-y-8">
       {/* Header */}
       <div className="text-center">
-        <h1 className="text-3xl font-bold text-white mb-2">
+        <h1 className="text-h1 text-white mb-2">
           💳 Gestión de Créditos
         </h1>
         <p className="text-slate-300">
@@ -140,18 +140,16 @@ export const CreditPurchase: React.FC = () => {
 
       {/* Paquetes de créditos */}
       <div className="bg-slate-800/30 backdrop-blur-sm rounded-xl border border-slate-700/50 p-6">
-        <h2 className="text-2xl font-bold text-white mb-6 text-center">
+        <h2 className="text-h2 text-white mb-6 text-center">
           🎯 Paquetes de Créditos
         </h2>
         
         <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4">
           {creditPackages.map((pkg, index) => (
-            <div 
+            <div
               key={index}
-              className={`relative p-4 rounded-lg border transition-all duration-200 hover:scale-105 ${
-                pkg.popular 
-                  ? 'bg-gradient-to-br from-blue-500/20 to-purple-500/20 border-blue-500/50' 
-                  : 'bg-slate-700/30 border-slate-600/30 hover:border-blue-500/30'
+              className={`card relative transition-all duration-200 hover:scale-105 ${
+                pkg.popular ? 'border-primary' : ''
               }`}
             >
               {pkg.popular && (
@@ -161,8 +159,8 @@ export const CreditPurchase: React.FC = () => {
                   </span>
                 </div>
               )}
-              
-              <div className="text-center">
+
+              <div className="card-body text-center">
                 <div className="text-2xl font-bold text-white mb-1">
                   {pkg.credits + pkg.bonus}
                 </div>
@@ -181,7 +179,7 @@ export const CreditPurchase: React.FC = () => {
                 <button
                   onClick={() => handlePurchaseCredits(pkg.credits)}
                   disabled={isLoading}
-                  className="w-full bg-blue-500 hover:bg-blue-600 text-white py-2 px-3 rounded text-sm transition-colors disabled:opacity-50"
+                  className="btn btn-primary w-full text-sm disabled:opacity-50"
                 >
                   {isLoading ? 'Comprando...' : 'Comprar'}
                 </button>
@@ -193,18 +191,16 @@ export const CreditPurchase: React.FC = () => {
 
       {/* Planes de suscripción */}
       <div className="bg-slate-800/30 backdrop-blur-sm rounded-xl border border-slate-700/50 p-6">
-        <h2 className="text-2xl font-bold text-white mb-6 text-center">
+        <h2 className="text-h2 text-white mb-6 text-center">
           🚀 Planes de Suscripción
         </h2>
         
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {plans.map((plan) => (
-            <div 
+            <div
               key={plan.id}
-              className={`relative p-6 rounded-lg border transition-all duration-200 ${
-                plan.popular 
-                  ? 'bg-gradient-to-br from-blue-500/20 to-purple-500/20 border-blue-500/50 scale-105' 
-                  : 'bg-slate-700/30 border-slate-600/30'
+              className={`card relative transition-all duration-200 ${
+                plan.popular ? 'border-primary scale-105' : ''
               }`}
             >
               {plan.popular && (
@@ -214,20 +210,21 @@ export const CreditPurchase: React.FC = () => {
                   </span>
                 </div>
               )}
-              
-              <div className="text-center mb-4">
-                <h3 className="text-xl font-bold text-white mb-2">{plan.name}</h3>
-                <div className="text-3xl font-bold text-blue-400 mb-1">
-                  €{plan.price}
-                </div>
-                <div className="text-slate-400 text-sm">por mes</div>
-              </div>
-              
-              <div className="mb-6">
+
+              <div className="card-body">
                 <div className="text-center mb-4">
-                  <span className="text-lg font-bold text-green-400">{plan.credits}</span>
-                  <span className="text-slate-400 text-sm ml-1">créditos/mes</span>
+                  <h3 className="text-xl font-bold text-white mb-2">{plan.name}</h3>
+                  <div className="text-3xl font-bold text-blue-400 mb-1">
+                    €{plan.price}
+                  </div>
+                  <div className="text-slate-400 text-sm">por mes</div>
                 </div>
+
+                <div className="mb-6">
+                  <div className="text-center mb-4">
+                    <span className="text-lg font-bold text-green-400">{plan.credits}</span>
+                    <span className="text-slate-400 text-sm ml-1">créditos/mes</span>
+                  </div>
                 
                 <ul className="space-y-2">
                   {plan.features.map((feature, index) => (
@@ -242,13 +239,11 @@ export const CreditPurchase: React.FC = () => {
               <button
                 onClick={() => handleUpgradePlan(plan.id)}
                 disabled={isLoading || user?.plan === plan.id}
-                className={`w-full py-2 px-4 rounded font-medium transition-colors ${
+                className={`btn w-full font-medium transition-colors ${
                   user?.plan === plan.id
-                    ? 'bg-gray-500 text-gray-300 cursor-not-allowed'
-                    : plan.popular
-                    ? 'bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white'
-                    : 'bg-blue-500 hover:bg-blue-600 text-white'
-                } disabled:opacity-50`}
+                    ? 'btn-secondary cursor-not-allowed opacity-50'
+                    : 'btn-primary'
+                }`}
               >
                 {user?.plan === plan.id 
                   ? 'Plan Actual' 
@@ -256,7 +251,8 @@ export const CreditPurchase: React.FC = () => {
                   ? 'Actualizando...' 
                   : 'Seleccionar Plan'
                 }
-              </button>
+                </button>
+              </div>
             </div>
           ))}
         </div>

--- a/frontend/src/components/PopularConversions.tsx
+++ b/frontend/src/components/PopularConversions.tsx
@@ -78,9 +78,9 @@ const popularData: Record<FileCategory, CategoryInfo> = {
 const displayCategories: FileCategory[] = ['ebook', 'audio', 'video', 'image', 'document', 'archive', 'presentation'];
 
 const ConversionButton: React.FC<{from: string, to: string}> = ({ from, to }) => (
-    <button className="w-full flex items-center justify-between p-4 bg-white border border-slate-300 rounded-lg hover:border-blue-500 hover:shadow-md transition-all duration-200 group">
-        <span className="font-semibold text-slate-700">{from} a {to}</span>
-        <IconArrowRight className="w-5 h-5 text-slate-400 group-hover:text-blue-500 transition-colors" />
+    <button className="popular-conversion-card w-full flex items-center justify-between">
+        <span className="font-semibold">{from} a {to}</span>
+        <IconArrowRight className="w-5 h-5" />
     </button>
 );
 
@@ -92,7 +92,7 @@ export const PopularConversions: React.FC = () => {
 
     return (
         <section className="w-full max-w-6xl mx-auto py-16 sm:py-24">
-            <h2 className="text-3xl sm:text-4xl font-bold text-slate-800 tracking-tight text-center mb-12">
+            <h2 className="text-h2 text-center mb-12">
                 Accede rápidamente a nuestras solicitudes de conversión más populares
             </h2>
             <div className="flex flex-col md:flex-row gap-8 lg:gap-12">


### PR DESCRIPTION
## Summary
- adopt brand class names in `ConversionSuccess`
- rework `CreditPurchase` layout to use brand classes
- update `PopularConversions` styles

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_688310a5cb448320aa31b922f8fc0eda