### PR TITLE
Load secrets from environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ PORT=3001
 GEMINI_API_KEY=1030319208863
 VITE_API_BASE_URL=http://localhost:3001/api
 SUPABASE_BUCKET=files
+SECRET_KEY=your-secret-key
+JWT_SECRET_KEY=your-jwt-secret-key

--- a/README.md
+++ b/README.md
@@ -84,10 +84,20 @@ npm install
 cp .env.example .env.local
 cp frontend/.env.example frontend/.env.local
 # Edit `frontend/.env.local` and set `NEXT_PUBLIC_API_BASE_URL` to the URL of your backend API
+# Define `SECRET_KEY` y `JWT_SECRET_KEY` en `.env.local` o variables de entorno del sistema
 
 # Iniciar en modo desarrollo
 npm run dev
 ```
+
+### Variables de entorno requeridas
+
+El backend requiere las siguientes variables para ejecutarse:
+
+- `SECRET_KEY`: clave usada por Flask para sesiones y cookies.
+- `JWT_SECRET_KEY`: clave usada para firmar y verificar tokens JWT.
+
+Asegúrate de definirlas en tu `.env.local` o como variables de entorno del sistema antes de iniciar el servidor.
 
 ### Uso Básico
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -16,8 +16,13 @@ from datetime import timedelta
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
 
 # Configuración de seguridad
-app.config['SECRET_KEY'] = 'anclora-metaform-secret-key-2024'
-app.config['JWT_SECRET_KEY'] = 'anclora-jwt-secret-key-2024'
+secret_key = os.environ.get('SECRET_KEY')
+jwt_secret_key = os.environ.get('JWT_SECRET_KEY')
+if not secret_key or not jwt_secret_key:
+    raise RuntimeError('SECRET_KEY and JWT_SECRET_KEY must be set as environment variables')
+
+app.config['SECRET_KEY'] = secret_key
+app.config['JWT_SECRET_KEY'] = jwt_secret_key
 app.config['JWT_ACCESS_TOKEN_EXPIRES'] = timedelta(days=7)
 
 # Configuración de CORS para permitir requests del frontend


### PR DESCRIPTION
## Summary
- Fetch Flask `SECRET_KEY` and `JWT_SECRET_KEY` from environment variables
- Add secret key placeholders to `.env.example`
- Document required backend secrets in README

## Testing
- `SECRET_KEY=dev JWT_SECRET_KEY=jwtdev timeout 3 python backend/src/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c1fcf70e48320809ac1919da8b68c