### PR TITLE
Add unit and integration tests for conversion and credits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+          pip install -r backend/requirements-test.txt
+      - name: Run tests
+        run: pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,12 +1,16 @@
-[tool:pytest]
-testpaths = tests/unit
+[pytest]
+testpaths =
+    tests/unit
+    tests/integration
+norecursedirs = scripts
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = -v --tb=short --strict-config --strict-markers
+addopts = -v --tb=short --strict-config --strict-markers --ignore=scripts/test_automation.py
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     integration: marks tests as integration tests
     unit: marks tests as unit tests
     auth: marks tests related to authentication
     credits: marks tests related to credits system
+    conversion: marks tests related to conversion functionality

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import pytest
+
+from flask import Flask
+from flask_jwt_extended import JWTManager
+
+# Añadir backend al path
+backend_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'backend')
+sys.path.insert(0, backend_path)
+
+from src.models.user import db, User
+from src.routes.auth import auth_bp
+from src.routes.credits import credits_bp
+from src.routes.conversion import conversion_bp
+from flask_jwt_extended import create_access_token
+
+
+@pytest.fixture
+def app():
+    """Aplicación Flask configurada para pruebas de integración"""
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SECRET_KEY'] = 'test-secret-key'
+    app.config['JWT_SECRET_KEY'] = 'test-jwt-secret'
+
+    db.init_app(app)
+    JWTManager(app)
+
+    app.register_blueprint(auth_bp, url_prefix='/api/auth')
+    app.register_blueprint(credits_bp, url_prefix='/api/credits')
+    app.register_blueprint(conversion_bp, url_prefix='/api/conversion')
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def auth_headers(client, app):
+    """Registra un usuario y genera un token de acceso"""
+    user_data = {
+        'email': 'integration@example.com',
+        'password': 'Password1',
+        'full_name': 'Integration User'
+    }
+    client.post('/api/auth/register', json=user_data)
+    with app.app_context():
+        user = User.query.filter_by(email=user_data['email']).first()
+        token = create_access_token(identity=str(user.id))
+    return {'Authorization': f'Bearer {token}'}

--- a/tests/integration/test_auth_routes.py
+++ b/tests/integration/test_auth_routes.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+class TestAuthRoutes:
+    def test_register_and_login(self, client):
+        """Debe permitir registrar y luego iniciar sesión"""
+        register_data = {
+            'email': 'user@example.com',
+            'password': 'Password1',
+            'full_name': 'User Example'
+        }
+        resp = client.post('/api/auth/register', json=register_data)
+        assert resp.status_code == 201
+        assert 'access_token' in resp.get_json()
+
+        login_data = {'email': 'user@example.com', 'password': 'Password1'}
+        resp = client.post('/api/auth/login', json=login_data)
+        assert resp.status_code == 200
+        assert 'access_token' in resp.get_json()

--- a/tests/integration/test_conversion_routes.py
+++ b/tests/integration/test_conversion_routes.py
@@ -1,0 +1,22 @@
+import io
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.conversion
+class TestConversionRoutes:
+    def test_convert_txt_to_html(self, client, auth_headers):
+        data = {
+            'file': (io.BytesIO(b'hello world'), 'test.txt'),
+            'target_format': 'html'
+        }
+        resp = client.post(
+            '/api/conversion/convert',
+            data=data,
+            headers=auth_headers,
+            content_type='multipart/form-data'
+        )
+        assert resp.status_code == 200
+        result = resp.get_json()
+        assert result['conversion']['status'] == 'completed'
+        assert result['user_credits_remaining'] == 9

--- a/tests/integration/test_credits_routes.py
+++ b/tests/integration/test_credits_routes.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.credits
+class TestCreditsRoutes:
+    def test_get_balance(self, client, auth_headers):
+        resp = client.get('/api/credits/balance', headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['credits'] == 10
+
+    def test_purchase_credits(self, client, auth_headers):
+        resp = client.post('/api/credits/purchase', json={'amount': 50}, headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['new_balance'] == 60

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -19,6 +19,8 @@ pip install -r requirements-test.txt
 tests/unit/
 ├── conftest.py              # Configuración de fixtures para pytest
 ├── test_user_model.py       # Pruebas para el modelo User
+├── test_conversion_models.py # Pruebas para Conversion y CreditTransaction
+├── test_conversion_engine.py # Pruebas para ConversionEngine
 └── README.md               # Este archivo
 ```
 
@@ -30,19 +32,16 @@ tests/unit/
 python -m pytest tests/unit/ -v
 ```
 
-### Pruebas específicas del modelo User
+### Pruebas específicas
 ```bash
+# Modelo User
 python -m pytest tests/unit/test_user_model.py -v
-```
 
-### Con reporte de cobertura
-```bash
-python -m pytest tests/unit/test_user_model.py --cov=src.models.user --cov-report=term-missing
-```
+# Modelos Conversion y CreditTransaction
+python -m pytest tests/unit/test_conversion_models.py -v
 
-### Con reporte HTML de cobertura
-```bash
-python -m pytest tests/unit/test_user_model.py --cov=src.models.user --cov-report=html
+# Motor de conversión
+python -m pytest tests/unit/test_conversion_engine.py -v
 ```
 
 ## Pruebas del modelo User

--- a/tests/unit/test_conversion_engine.py
+++ b/tests/unit/test_conversion_engine.py
@@ -1,0 +1,39 @@
+import os
+
+from src.models.conversion import ConversionEngine
+
+
+class TestConversionEngine:
+    """Pruebas unitarias para ConversionEngine"""
+
+    def test_get_supported_formats(self):
+        engine = ConversionEngine()
+        formats = engine.get_supported_formats('txt')
+        assert 'html' in formats
+        assert 'pdf' in formats
+
+    def test_get_conversion_cost(self):
+        engine = ConversionEngine()
+        assert engine.get_conversion_cost('txt', 'html') == 1
+        assert engine.get_conversion_cost('jpg', 'gif') == 2
+
+    def test_validate_file(self, tmp_path):
+        engine = ConversionEngine()
+        missing = tmp_path / 'missing.txt'
+        assert engine.validate_file(str(missing))[0] is False
+        valid = tmp_path / 'valid.txt'
+        valid.write_text('hello')
+        assert engine.validate_file(str(valid))[0] is True
+
+    def test_convert_txt_to_html(self, tmp_path):
+        engine = ConversionEngine()
+        input_file = tmp_path / 'input.txt'
+        input_file.write_text('hola mundo')
+        output_file = tmp_path / 'output.html'
+        success, message = engine.convert_file(
+            str(input_file), str(output_file), 'txt', 'html'
+        )
+        assert success is True
+        assert os.path.exists(output_file)
+        content = output_file.read_text()
+        assert '<html' in content.lower()

--- a/tests/unit/test_conversion_models.py
+++ b/tests/unit/test_conversion_models.py
@@ -1,0 +1,89 @@
+import pytest
+from src.models.user import User, Conversion, CreditTransaction, db
+
+
+class TestConversionModel:
+    """Pruebas para el modelo Conversion"""
+
+    def test_to_dict_and_defaults(self, app):
+        """Conversion.to_dict debe incluir campos básicos y estado por defecto"""
+        with app.app_context():
+            user = User(email='conv@example.com', full_name='Conv Test')
+            user.set_password('pass')
+            db.session.add(user)
+            db.session.commit()
+
+            conversion = Conversion(
+                user_id=user.id,
+                original_filename='demo.txt',
+                original_format='txt',
+                target_format='html',
+                file_size=100,
+                conversion_type='txt-html',
+                credits_used=1,
+            )
+            db.session.add(conversion)
+            db.session.commit()
+
+            data = conversion.to_dict()
+            assert data['original_filename'] == 'demo.txt'
+            assert data['status'] == 'pending'
+            assert data['credits_used'] == 1
+            assert data['output_filename'] is None
+
+    def test_repr(self, app):
+        with app.app_context():
+            user = User(email='repr@example.com', full_name='Repr Test')
+            user.set_password('pass')
+            db.session.add(user)
+            db.session.commit()
+
+            conversion = Conversion(
+                user_id=user.id,
+                original_filename='file.pdf',
+                original_format='pdf',
+                target_format='txt',
+                file_size=200,
+                conversion_type='pdf-txt',
+                credits_used=4,
+            )
+            assert repr(conversion) == '<Conversion file.pdf -> txt>'
+
+
+class TestCreditTransactionModel:
+    """Pruebas para el modelo CreditTransaction"""
+
+    def test_to_dict(self, app):
+        with app.app_context():
+            user = User(email='credit@example.com', full_name='Credit Test')
+            user.set_password('pass')
+            db.session.add(user)
+            db.session.commit()
+
+            trans = CreditTransaction(
+                user_id=user.id,
+                amount=-5,
+                transaction_type='conversion',
+                description='Uso de créditos',
+            )
+            db.session.add(trans)
+            db.session.commit()
+
+            data = trans.to_dict()
+            assert data['amount'] == -5
+            assert data['transaction_type'] == 'conversion'
+            assert data['description'] == 'Uso de créditos'
+
+    def test_repr(self, app):
+        with app.app_context():
+            user = User(email='repr2@example.com', full_name='Repr2 Test')
+            user.set_password('pass')
+            db.session.add(user)
+            db.session.commit()
+
+            trans = CreditTransaction(
+                user_id=user.id,
+                amount=10,
+                transaction_type='purchase',
+            )
+            assert repr(trans) == f'<CreditTransaction 10 credits for user {user.id}>'


### PR DESCRIPTION
## Summary
- add unit tests for Conversion, CreditTransaction, and ConversionEngine
- add integration tests for auth, credit, and conversion routes with temp DB fixtures
- run tests in CI via GitHub Actions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c1fc78a7c8320af2300f5f5f09f1c