### PR TITLE
feat: add webp svg mp4 conversions

### DIFF
--- a/backend/src/routes/conversion.py
+++ b/backend/src/routes/conversion.py
@@ -20,7 +20,7 @@ os.makedirs(OUTPUT_FOLDER, exist_ok=True)
 
 ALLOWED_EXTENSIONS = {
     'txt', 'pdf', 'doc', 'docx', 'jpg', 'jpeg', 'png', 'gif',
-    'html', 'md', 'rtf', 'odt', 'tex'
+    'html', 'md', 'rtf', 'odt', 'tex', 'webp', 'svg', 'mp4'
 }
 
 def allowed_file(filename):

--- a/docs/SISTEMA_VALORACION_CREDITOS.md
+++ b/docs/SISTEMA_VALORACION_CREDITOS.md
@@ -80,9 +80,12 @@ Las conversiones básicas representan transformaciones directas entre formatos s
 
 **Conversiones de Imagen Básicas:**
 - JPG ↔ PNG (1 crédito): Conversión directa entre formatos raster comunes
-- BMP → JPG (1 crédito): Compresión básica sin pérdida de calidad significativa  
-- GIF → PNG (1 crédito): Preservación de transparencia básica
-- WEBP → JPG (1 crédito): Conversión de formato web moderno a estándar
+- JPG ↔ WEBP (1 crédito): Optimización para web moderna
+- PNG ↔ WEBP (1 crédito): Optimización web con transparencia
+- PNG ↔ SVG (2 créditos): Raster a vector básico
+- GIF ↔ PNG (1 crédito): Preservación de transparencia básica
+- GIF ↔ WEBP (2 créditos): Animación optimizada
+- BMP → JPG (1 crédito): Compresión básica sin pérdida de calidad significativa
 
 **Conversiones de Documento Simples:**
 - TXT → PDF (1 crédito): Generación de PDF básico sin formateo complejo
@@ -105,6 +108,7 @@ Las conversiones estándar involucran procesamiento más complejo, utilización 
 - MOV → MP4 (3 créditos): Conversión entre formatos de contenedor populares
 - WMV → MP4 (4 créditos): Migración desde formato propietario Microsoft
 - FLV → MP4 (4 créditos): Conversión desde formato Flash legacy
+- MP4 ↔ GIF (5 créditos): Conversión básica entre video y animación
 
 **Procesamiento de Audio Profesional:**
 - WAV → FLAC (3 créditos): Compresión sin pérdida con algoritmos avanzados

--- a/docs/conversion_analysis.md
+++ b/docs/conversion_analysis.md
@@ -12,6 +12,9 @@
 - mov → mp4
 - png → jpg, webp
 - jpg → png, webp
+- webp → jpg, png
+- png → svg
+- svg → png
 - docx → pdf, txt
 - pdf → docx
 

--- a/tests/integration/test_conversion_routes.py
+++ b/tests/integration/test_conversion_routes.py
@@ -1,5 +1,6 @@
 import io
 import pytest
+from PIL import Image
 
 
 @pytest.mark.integration
@@ -20,3 +21,55 @@ class TestConversionRoutes:
         result = resp.get_json()
         assert result['conversion']['status'] == 'completed'
         assert result['user_credits_remaining'] == 9
+
+    def test_convert_png_to_webp(self, client, auth_headers):
+        img_bytes = io.BytesIO()
+        Image.new('RGB', (10, 10), color='blue').save(img_bytes, format='PNG')
+        img_bytes.seek(0)
+        data = {
+            'file': (img_bytes, 'test.png'),
+            'target_format': 'webp'
+        }
+        resp = client.post(
+            '/api/conversion/convert',
+            data=data,
+            headers=auth_headers,
+            content_type='multipart/form-data'
+        )
+        assert resp.status_code == 200
+        result = resp.get_json()
+        assert result['conversion']['status'] == 'completed'
+        assert result['user_credits_remaining'] == 9
+
+    def test_convert_svg_to_png(self, client, auth_headers):
+        svg_data = b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>'
+        data = {
+            'file': (io.BytesIO(svg_data), 'test.svg'),
+            'target_format': 'png'
+        }
+        resp = client.post(
+            '/api/conversion/convert',
+            data=data,
+            headers=auth_headers,
+            content_type='multipart/form-data'
+        )
+        assert resp.status_code == 200
+        result = resp.get_json()
+        assert result['conversion']['status'] == 'completed'
+        assert result['user_credits_remaining'] == 8
+
+    def test_convert_mp4_to_gif(self, client, auth_headers):
+        data = {
+            'file': (io.BytesIO(b'fake mp4 data'), 'test.mp4'),
+            'target_format': 'gif'
+        }
+        resp = client.post(
+            '/api/conversion/convert',
+            data=data,
+            headers=auth_headers,
+            content_type='multipart/form-data'
+        )
+        assert resp.status_code == 200
+        result = resp.get_json()
+        assert result['conversion']['status'] == 'completed'
+        assert result['user_credits_remaining'] == 5

--- a/tests/unit/test_conversion_engine.py
+++ b/tests/unit/test_conversion_engine.py
@@ -20,6 +20,15 @@ def create_sample_file(ext: str, path: str):
     elif ext in ('jpg', 'png', 'gif'):
         img = Image.new('RGB', (50, 50), color='red')
         img.save(path)
+    elif ext == 'webp':
+        img = Image.new('RGB', (50, 50), color='blue')
+        img.save(path, 'WEBP')
+    elif ext == 'svg':
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write('<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>')
+    elif ext == 'mp4':
+        with open(path, 'wb') as f:
+            f.write(b'fake mp4 data')
     elif ext == 'docx':
         doc = Document()
         doc.add_paragraph('hola docx')
@@ -34,9 +43,12 @@ def create_sample_file(ext: str, path: str):
 @pytest.mark.parametrize('source_ext,target_ext', [
     ('txt', 'doc'), ('txt', 'docx'), ('txt', 'pdf'), ('txt', 'odt'), ('txt', 'tex'),
     ('pdf', 'jpg'), ('pdf', 'png'), ('pdf', 'gif'), ('pdf', 'txt'),
-    ('jpg', 'png'), ('jpg', 'pdf'), ('jpg', 'gif'),
-    ('png', 'jpg'), ('png', 'pdf'), ('png', 'gif'),
-    ('gif', 'jpg'), ('gif', 'png'), ('gif', 'pdf'),
+    ('jpg', 'png'), ('jpg', 'pdf'), ('jpg', 'gif'), ('jpg', 'webp'),
+    ('png', 'jpg'), ('png', 'pdf'), ('png', 'gif'), ('png', 'webp'), ('png', 'svg'),
+    ('gif', 'jpg'), ('gif', 'png'), ('gif', 'pdf'), ('gif', 'webp'), ('gif', 'mp4'),
+    ('webp', 'jpg'), ('webp', 'png'), ('webp', 'gif'),
+    ('svg', 'png'),
+    ('mp4', 'gif'),
     ('doc', 'pdf'), ('doc', 'txt'), ('doc', 'html'),
     ('docx', 'pdf'), ('docx', 'txt'), ('docx', 'html')
 ])


### PR DESCRIPTION
## Summary
- support WebP, SVG and MP4 conversions with credit costs
- document new conversion capabilities
- test conversion engine and API routes for new formats

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d1bb77a508320972c420009f71fdf