### PR TITLE
fix: secure CORS and debug configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ pip install -r requirements.txt
 python main.py
 ```
 
+### Variables de entorno (Backend)
+
+Antes de ejecutar el backend, configura las siguientes variables de entorno:
+
+- `SECRET_KEY`: clave usada por Flask para sesiones.
+- `JWT_SECRET_KEY`: clave para firmar tokens JWT.
+- `CORS_ORIGINS`: lista separada por comas de orígenes permitidos para CORS (ej. `http://localhost:3000,http://localhost:5173`).
+- `FLASK_DEBUG`: establece `true` para habilitar el modo debug (opcional).
+
 ### Ejecutar Tests
 ```bash
 # Frontend

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -26,8 +26,12 @@ app.config['JWT_SECRET_KEY'] = jwt_secret_key
 app.config['JWT_ACCESS_TOKEN_EXPIRES'] = timedelta(days=7)
 
 # Configuración de CORS para permitir requests del frontend
-CORS(app, 
-     origins=['http://localhost:3000', 'http://localhost:5173', '*'],
+allowed_origins = os.environ.get('CORS_ORIGINS')
+if not allowed_origins:
+    raise RuntimeError('CORS_ORIGINS must be set as environment variable')
+origins = [origin.strip() for origin in allowed_origins.split(',') if origin.strip()]
+CORS(app,
+     origins=origins,
      supports_credentials=True,
      allow_headers=['Content-Type', 'Authorization'])
 
@@ -139,6 +143,6 @@ if __name__ == '__main__':
     print("🔍 Información del API: http://localhost:8000/api/info")
     print("❤️  Verificación de salud: http://localhost:8000/api/health")
     print("=" * 50)
-    
-    app.run(host='0.0.0.0', port=8000, debug=True)
+    debug_mode = os.environ.get('FLASK_DEBUG', 'false').lower() in ('1', 'true', 'yes')
+    app.run(host='0.0.0.0', port=8000, debug=debug_mode)
 


### PR DESCRIPTION
## Summary
- secure CORS origins via `CORS_ORIGINS` environment variable
- toggle Flask debug with `FLASK_DEBUG`
- document backend environment variables

## Testing
- `python -m pytest tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_689d4cf0612483208ef3fddb75d5ac4c