### PR TITLE
test: cover credit management flows

### DIFF
--- a/tests/integration/test_credits_routes.py
+++ b/tests/integration/test_credits_routes.py
@@ -1,4 +1,7 @@
+import io
 import pytest
+from flask_jwt_extended import create_access_token
+from src.models.user import User, db
 
 
 @pytest.mark.integration
@@ -15,3 +18,59 @@ class TestCreditsRoutes:
         assert resp.status_code == 200
         data = resp.get_json()
         assert data['new_balance'] == 60
+
+    def test_gift_credits(self, client, app):
+        with app.app_context():
+            admin = User(email='admin@example.com', full_name='Admin User', plan='ENTERPRISE', credits=100)
+            admin.set_password('Password1')
+            recipient = User(email='friend@example.com', full_name='Friend', credits=0)
+            recipient.set_password('Password1')
+            db.session.add_all([admin, recipient])
+            db.session.commit()
+            token = create_access_token(identity=str(admin.id))
+
+        headers = {'Authorization': f'Bearer {token}'}
+        payload = {'recipient_email': 'friend@example.com', 'amount': 5}
+        resp = client.post('/api/credits/gift', json=payload, headers=headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['recipient_new_balance'] == 5
+
+    def test_upgrade_plan(self, client, auth_headers):
+        resp = client.post('/api/credits/upgrade-plan', json={'plan': 'BASIC'}, headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['new_plan'] == 'BASIC'
+        assert data['new_balance'] == 100
+
+    def test_upgrade_plan_invalid(self, client, auth_headers):
+        resp = client.post('/api/credits/upgrade-plan', json={'plan': 'PREMIUM'}, headers=auth_headers)
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data['error'] == 'Plan inválido'
+
+    def test_usage_stats(self, client, auth_headers):
+        resp = client.get('/api/credits/usage-stats', headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['current_balance'] == 10
+
+    def test_insufficient_credits(self, client, auth_headers, app):
+        with app.app_context():
+            user = User.query.filter_by(email='integration@example.com').first()
+            user.credits = 0
+            db.session.commit()
+
+        data = {
+            'file': (io.BytesIO(b'hello'), 'test.txt'),
+            'target_format': 'html'
+        }
+        resp = client.post(
+            '/api/conversion/convert',
+            data=data,
+            headers=auth_headers,
+            content_type='multipart/form-data'
+        )
+        assert resp.status_code == 402
+        result = resp.get_json()
+        assert result['error'] == 'Créditos insuficientes'


### PR DESCRIPTION
## Summary
- add integration tests for gifting credits and plan upgrades
- exercise usage stats endpoint and upgrade errors for invalid plan
- ensure insufficient credit scenarios return proper error

## Testing
- `pytest tests/integration/test_credits_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689d51026aec832080f28fefc7f00e30