### PR TITLE
feat: add forgot password flow

### DIFF
--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { AuthService } from '../services/authService';
+import { apiService } from '../services/api';
 
 interface LoginProps {
   onSuccess?: () => void;
@@ -69,6 +70,19 @@ export const Login: React.FC<LoginProps> = ({
     }));
     // Limpiar error cuando el usuario empiece a escribir
     if (error) setError('');
+  };
+
+  const handleForgotPassword = async () => {
+    if (!formData.email) {
+      setError('Por favor ingresa tu correo electrónico');
+      return;
+    }
+    try {
+      await apiService.requestPasswordReset(formData.email);
+      alert('Se ha enviado un enlace de recuperación a tu correo.');
+    } catch (e) {
+      setError('No se pudo iniciar la recuperación de contraseña');
+    }
   };
 
   return (
@@ -186,8 +200,8 @@ export const Login: React.FC<LoginProps> = ({
 
         {/* Footer Links */}
         <div className="login-footer">
-          <button 
-            onClick={() => {/* TODO: Implementar forgot password */}}
+          <button
+            onClick={handleForgotPassword}
             className="link-button"
           >
             ¿Olvidaste tu contraseña?

--- a/frontend/src/components/__tests__/Login.test.tsx
+++ b/frontend/src/components/__tests__/Login.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { Login } from '../Login';
+import { apiService } from '../../services/api';
+
+vi.mock('../../services/authService', () => ({
+  AuthService: {
+    getInstance: () => ({
+      signIn: vi.fn(),
+      signInWithGoogle: vi.fn(),
+      requestPasswordReset: vi.fn(),
+    }),
+  },
+}), { virtual: true });
+vi.mock('../../services/api', () => ({
+  apiService: {
+    requestPasswordReset: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+describe('Login forgot password flow', () => {
+  it('requests password reset when email provided', async () => {
+    window.alert = vi.fn();
+    render(<Login />);
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'user@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: '¿Olvidaste tu contraseña?' }));
+    await waitFor(() => {
+      expect(apiService.requestPasswordReset).toHaveBeenCalledWith('user@example.com');
+    });
+  });
+
+  it('shows error when email is missing', async () => {
+    render(<Login />);
+    fireEvent.click(screen.getByRole('button', { name: '¿Olvidaste tu contraseña?' }));
+    expect(apiService.requestPasswordReset).not.toHaveBeenCalled();
+    expect(screen.getByText('Por favor ingresa tu correo electrónico')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -68,6 +68,18 @@ export const apiService = {
     return { token: responseData.access_token, user: responseData.user };
   },
 
+  requestPasswordReset: async (email: string): Promise<void> => {
+    const response = await fetch(`${API_BASE_URL}/auth/forgot-password`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error(data.error || 'Error solicitando recuperación de contraseña');
+    }
+  },
+
   logout: () => {
     console.log('Cerrando sesión...');
     clearToken();

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,0 +1,39 @@
+import { apiService } from './api';
+
+interface ServiceResult {
+  success: boolean;
+  error?: string;
+}
+
+export class AuthService {
+  private static instance: AuthService;
+
+  static getInstance(): AuthService {
+    if (!AuthService.instance) {
+      AuthService.instance = new AuthService();
+    }
+    return AuthService.instance;
+  }
+
+  async signIn(email: string, password: string): Promise<ServiceResult> {
+    try {
+      await apiService.login({ email, password });
+      return { success: true };
+    } catch (e: any) {
+      return { success: false, error: e.message };
+    }
+  }
+
+  async signInWithGoogle(): Promise<ServiceResult> {
+    return { success: false, error: 'Not implemented' };
+  }
+
+  async requestPasswordReset(email: string): Promise<ServiceResult> {
+    try {
+      await apiService.requestPasswordReset(email);
+      return { success: true };
+    } catch (e: any) {
+      return { success: false, error: e.message };
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- handle password recovery from Login component
- add API service stub for password reset
- cover forgot password flow with tests

## Testing
- `npx vitest run src/components/__tests__/Login.test.tsx --environment jsdom`


------
https://chatgpt.com/codex/tasks/task_e_689d50ffb52483208774b140ddd79d97