### PR TITLE
feat: animate sidebar and converter with framer-motion

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",
+        "framer-motion": "^12.23.12",
         "lucide-react": "^0.532.0",
         "next": "^14.2.30",
         "react": "^18",
@@ -4737,6 +4738,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6429,6 +6457,21 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "next": "^14.2.30",
     "react": "^18",
     "react-dom": "^18",
+    "framer-motion": "^12.23.12",
     "tailwind-merge": "^3.3.1",
     "tailwind-variants": "^2.0.1",
     "tailwindcss-animate": "^1.0.7"

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 // frontend/src/components/Layout/Sidebar.tsx
 import React from "react";
+import { motion } from "framer-motion";
 import {
   Home, FileText, History, CreditCard, Star,
   Settings, HelpCircle, BarChart, LogOut
@@ -32,13 +33,20 @@ export const Sidebar: React.FC<SidebarProps> = ({
     { name: "Estadísticas", icon: BarChart },
   ];
 
+  const sidebarVariants = {
+    hidden: { opacity: 0, x: -50 },
+    visible: { opacity: 1, x: 0, transition: { duration: 0.3 } },
+    exit: { opacity: 0, x: -50, transition: { duration: 0.2 } },
+  };
+
   return (
-    <aside
-      className={cn(
-        "fixed top-0 left-0 h-full z-40 bg-gradient-to-b from-slate-950 to-slate-800 text-white shadow-md transition-all duration-300 ease-in-out",
-        isCollapsed ? "w-16" : "w-72"
-      )}
-    >
+    <motion.div initial="hidden" animate="visible" exit="exit" variants={sidebarVariants}>
+      <aside
+        className={cn(
+          "fixed top-0 left-0 h-full z-40 bg-gradient-to-b from-slate-950 to-slate-800 text-white shadow-md transition-all duration-300 ease-in-out",
+          isCollapsed ? "w-16" : "w-72"
+        )}
+      >
       {/* Header del Sidebar */}
       <div className="flex items-center justify-between p-4 border-b border-slate-700/50">
         {/* Brand: logo and title only when not collapsed */}
@@ -102,6 +110,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
           {!isCollapsed && <span>Salir</span>}
         </Button>
       </div>
-    </aside>
+      </aside>
+    </motion.div>
   );
 };

--- a/frontend/src/components/UniversalConverter.tsx
+++ b/frontend/src/components/UniversalConverter.tsx
@@ -1,5 +1,6 @@
 // frontend/src/components/UniversalConverter.tsx
 import React, { useState, useRef, useCallback, useEffect, useMemo } from 'react';
+import { motion } from 'framer-motion';
 import { apiService, getConversionCost, formatFileSize } from '../services/api';
 import { useAuth } from '../auth/AuthContext';
 
@@ -33,9 +34,13 @@ const ConversionCard: React.FC<{
   isActive: boolean;
   isCompleted?: boolean;
 }> = ({ icon, title, children, isActive, isCompleted }) => (
-  <div className={`bg-gray-800/80 rounded-lg p-5 transition-all ${
-    isActive ? 'border-2 border-primary shadow-lg' : 'border border-gray-700/50'
-  }`}>
+  <motion.div
+    whileHover={{ scale: 1.02 }}
+    transition={{ type: 'spring', stiffness: 300 }}
+    className={`bg-gray-800/80 rounded-lg p-5 transition-all ${
+      isActive ? 'border-2 border-primary shadow-lg' : 'border border-gray-700/50'
+    }`}
+  >
     <div className="flex items-center mb-3">
       <div className="text-3xl mr-3">{icon}</div>
       <h3 className="text-xl font-semibold">{title}</h3>
@@ -46,7 +51,7 @@ const ConversionCard: React.FC<{
       )}
     </div>
     <div>{children}</div>
-  </div>
+  </motion.div>
 );
 
 // Componente de conversión popular
@@ -130,9 +135,20 @@ export const UniversalConverter: React.FC = () => {
       setIsConverting(false);
     }, 2000);
   }, [selectedFile, targetFormat]);
+  const containerVariants = {
+    hidden: { opacity: 0, y: 20 },
+    visible: { opacity: 1, y: 0, transition: { duration: 0.3 } },
+    exit: { opacity: 0, y: -20, transition: { duration: 0.2 } },
+  };
 
   return (
-    <div className="w-full max-w-6xl mx-auto p-6 space-y-8">
+    <motion.div
+      className="w-full max-w-6xl mx-auto p-6 space-y-8"
+      initial="hidden"
+      animate="visible"
+      exit="exit"
+      variants={containerVariants}
+    >
       {/* Encabezado */}
       <div className="text-center mb-8">
         <div className="flex items-center justify-center mb-2">
@@ -308,6 +324,6 @@ export const UniversalConverter: React.FC = () => {
           ))}
         </div>
       </div>
-    </div>
+    </motion.div>
   );
 };

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
@@ -33,10 +34,14 @@ export interface ButtonProps
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
+    const MotionComp = motion(Comp as any);
     return (
-      <Comp
+      <MotionComp
         className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
+        ref={ref as any}
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.95 }}
+        transition={{ type: "spring", stiffness: 400, damping: 17 }}
         {...props}
       />
     );


### PR DESCRIPTION
## Summary
- add framer-motion dependency
- animate sidebar and converter containers with fade/slide variants
- add hover transitions to UI button and conversion cards

## Testing
- `npm test` *(fails: "@vitejs/plugin-react" resolved to an ESM file)*

------
https://chatgpt.com/codex/tasks/task_e_689d5dde113883208d65d44ea6358e00