### PR TITLE
feat: add basic i18n support

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,12 +10,16 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.3",
+        "@testing-library/jest-dom": "^6.7.0",
+        "@testing-library/react": "^16.3.0",
         "class-variance-authority": "^0.7.1",
         "framer-motion": "^12.23.12",
+        "i18next": "^25.3.4",
         "lucide-react": "^0.532.0",
         "next": "^14.2.30",
         "react": "^18",
         "react-dom": "^18",
+        "react-i18next": "^15.6.1",
         "tailwind-merge": "^3.3.1",
         "tailwind-variants": "^2.0.1",
         "tailwindcss-animate": "^1.0.7"
@@ -36,6 +40,12 @@
         "typescript": "^5.8.3",
         "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -67,7 +77,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -269,7 +278,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
       "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -345,6 +353,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1932,6 +1949,88 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.7.0.tgz",
+      "integrity": "sha512-RI2e97YZ7MRa+vxP4UUnMuMFL2buSsf0ollxUbTgrbPLKhMn8KVTx7raS6DYjC7v1NDVrioOvaShxsguLNISCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -1949,6 +2048,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2058,7 +2164,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -2723,7 +2829,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
       "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -3544,6 +3649,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3738,6 +3849,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -3785,6 +3906,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5178,6 +5306,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.3.4",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.3.4.tgz",
+      "integrity": "sha512-AHklEYFLiRRxW1Cb6zE9lfnEtYvsydRC8nRS3RSKGX3zCqZ8nLZwMaUsrb80YuccPNv2RNokDL8LkTNnp+6mDw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -5234,6 +5402,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -6268,6 +6445,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -6321,6 +6508,15 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -7082,6 +7278,41 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -7159,6 +7390,32 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.6.1.tgz",
+      "integrity": "sha512-uGrzSsOUUe2sDBG/+FJq2J1MM+Y4368/QW8OLEKSFvnDflHBbZhSd1u3UkW0Z06rMhZmnB/AQrhCpYfE5/5XNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -7229,6 +7486,19 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -8021,6 +8291,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -8634,7 +8916,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8978,6 +9260,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,12 +11,16 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
+    "@testing-library/jest-dom": "^6.7.0",
+    "@testing-library/react": "^16.3.0",
     "class-variance-authority": "^0.7.1",
     "framer-motion": "^12.23.12",
+    "i18next": "^25.3.4",
     "lucide-react": "^0.532.0",
     "next": "^14.2.30",
     "react": "^18",
     "react-dom": "^18",
+    "react-i18next": "^15.6.1",
     "tailwind-merge": "^3.3.1",
     "tailwind-variants": "^2.0.1",
     "tailwindcss-animate": "^1.0.7"

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useAuth } from '../../auth/AuthContext';
+import { useTranslation } from 'react-i18next';
 
 
 interface HeaderProps {
@@ -8,11 +9,16 @@ interface HeaderProps {
 
 export const Header: React.FC<HeaderProps> = ({ sidebarCollapsed }) => {
   const { user } = useAuth();
+  const { t, i18n } = useTranslation();
+
+  const changeLanguage = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    i18n.changeLanguage(e.target.value);
+  };
 
   return (
     <header
       role="banner"
-      aria-label="Encabezado principal"
+      aria-label={t('header.ariaLabel')}
       className={`
         fixed top-0 right-0 h-16
         bg-gradient-to-br from-primary to-secondary
@@ -25,19 +31,27 @@ export const Header: React.FC<HeaderProps> = ({ sidebarCollapsed }) => {
         {/* Título de la página actual */}
         <div className="flex flex-col justify-center">
           <h1 className="text-xl font-bold text-white leading-snug">
-            Conversor Inteligente
+            {t('header.title')}
           </h1>
           <p className="text-sm text-blue-100 -mt-1">
-            Convierte archivos con inteligencia artificial avanzada
+            {t('header.subtitle')}
           </p>
         </div>
 
         {/* Área de usuario y créditos */}
         <div className="flex items-center space-x-4">
+          <select
+            value={i18n.language}
+            onChange={changeLanguage}
+            className="bg-slate-800 text-white px-2 py-1 rounded"
+          >
+            <option value="es">ES</option>
+            <option value="en">EN</option>
+          </select>
           {/* Contador de créditos */}
           <div className="flex items-center gap-2 bg-blue-700/60 px-3 py-1 rounded-full text-white shadow-sm">
             <div className="w-2 h-2 bg-green-400 rounded-full"></div>
-            <span className="text-sm font-medium">50 créditos</span>
+            <span className="text-sm font-medium">{t('header.credits', { count: 50 })}</span>
           </div>
 
           {/* Perfil de usuario */}
@@ -47,10 +61,10 @@ export const Header: React.FC<HeaderProps> = ({ sidebarCollapsed }) => {
             </div>
             <div className="flex-col hidden sm:flex leading-tight">
               <span className="text-sm text-white font-medium">
-                {user?.name || 'Usuario'}
+                {user?.name || t('header.defaultName')}
               </span>
               <span className="text-xs text-gray-300">
-                {user?.email || 'usuario@ejemplo.com'}
+                {user?.email || t('header.defaultEmail')}
               </span>
             </div>
             <svg className="w-4 h-4 text-white/50" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,0 +1,14 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import { resources } from './translations';
+
+i18n.use(initReactI18next).init({
+  resources,
+  lng: 'es',
+  fallbackLng: 'en',
+  interpolation: {
+    escapeValue: false,
+  },
+});
+
+export default i18n;

--- a/frontend/src/i18n/translations.ts
+++ b/frontend/src/i18n/translations.ts
@@ -1,0 +1,106 @@
+export const resources = {
+  en: {
+    translation: {
+      header: {
+        ariaLabel: 'Main header',
+        title: 'Smart Converter',
+        subtitle: 'Convert files with advanced artificial intelligence',
+        credits: '{{count}} credits',
+        defaultName: 'User',
+        defaultEmail: 'user@example.com'
+      },
+      landing: {
+        heroTitle: 'Anclora Metaform',
+        heroSubtitle: 'Your Content, Reinvented',
+        featuresTitle: 'Features',
+        features: {
+          smartConversion: {
+            title: 'Smart Conversion',
+            desc: 'Transform your files to multiple formats with AI.'
+          },
+          intuitiveDesign: {
+            title: 'Intuitive Design',
+            desc: 'Simple interface optimized for your workflow.'
+          },
+          multiplatformSupport: {
+            title: 'Multiplatform Support',
+            desc: 'Available on all your favorite devices.'
+          }
+        },
+        pricingTitle: 'Pricing',
+        pricing: {
+          free: {
+            title: 'Free',
+            desc: 'Basic features at no cost.',
+            cta: 'Get Started'
+          },
+          pro: {
+            title: 'Pro',
+            desc: 'Unlimited conversion and advanced features.',
+            cta: 'Choose Pro'
+          },
+          enterprise: {
+            title: 'Enterprise',
+            desc: 'Custom solutions for teams.',
+            cta: 'Contact Us'
+          }
+        },
+        ctaTitle: 'Ready to transform your content?',
+        ctaButton: 'Go to App'
+      }
+    }
+  },
+  es: {
+    translation: {
+      header: {
+        ariaLabel: 'Encabezado principal',
+        title: 'Conversor Inteligente',
+        subtitle: 'Convierte archivos con inteligencia artificial avanzada',
+        credits: '{{count}} créditos',
+        defaultName: 'Usuario',
+        defaultEmail: 'usuario@ejemplo.com'
+      },
+      landing: {
+        heroTitle: 'Anclora Metaform',
+        heroSubtitle: 'Tu Contenido, Reinventado',
+        featuresTitle: 'Características',
+        features: {
+          smartConversion: {
+            title: 'Conversión Inteligente',
+            desc: 'Transforma tus archivos a múltiples formatos con IA.'
+          },
+          intuitiveDesign: {
+            title: 'Diseño Intuitivo',
+            desc: 'Interfaz sencilla y optimizada para tu flujo de trabajo.'
+          },
+          multiplatformSupport: {
+            title: 'Soporte Multiplataforma',
+            desc: 'Disponible en todos tus dispositivos favoritos.'
+          }
+        },
+        pricingTitle: 'Precios',
+        pricing: {
+          free: {
+            title: 'Gratis',
+            desc: 'Funcionalidades básicas sin costo.',
+            cta: 'Comenzar'
+          },
+          pro: {
+            title: 'Pro',
+            desc: 'Conversión ilimitada y funciones avanzadas.',
+            cta: 'Elegir Pro'
+          },
+          enterprise: {
+            title: 'Empresa',
+            desc: 'Soluciones personalizadas para equipos.',
+            cta: 'Contáctanos'
+          }
+        },
+        ctaTitle: '¿Listo para transformar tu contenido?',
+        ctaButton: 'Ir a la App'
+      }
+    }
+  }
+} as const;
+
+export default resources;

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -2,12 +2,16 @@
 import '../styles/brand-styles.css';
 import type { AppProps } from 'next/app';
 import { AuthProvider } from '../auth/AuthContext';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../i18n';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <AuthProvider>
-      <Component {...pageProps} />
-    </AuthProvider>
+    <I18nextProvider i18n={i18n}>
+      <AuthProvider>
+        <Component {...pageProps} />
+      </AuthProvider>
+    </I18nextProvider>
   );
 }
 

--- a/frontend/src/pages/landing.tsx
+++ b/frontend/src/pages/landing.tsx
@@ -1,46 +1,48 @@
 import Link from "next/link";
+import { useTranslation } from "react-i18next";
 
 export default function LandingPage() {
+  const { t } = useTranslation();
   return (
     <div className="min-h-screen font-sans">
       {/* Hero Section */}
       <section className="bg-[#dbeafe] text-center py-24 px-4">
         <h1 className="text-4xl md:text-5xl font-bold text-[#1e40af] mb-4">
-          Anclora Metaform
+          {t('landing.heroTitle')}
         </h1>
         <p className="text-xl md:text-2xl text-[#2563eb] italic">
-          Tu Contenido, Reinventado
+          {t('landing.heroSubtitle')}
         </p>
       </section>
 
       {/* Features Section */}
       <section className="py-16 px-4">
         <h2 className="text-3xl font-semibold text-center text-[#1e40af] mb-12">
-          Características
+          {t('landing.featuresTitle')}
         </h2>
         <div className="max-w-5xl mx-auto grid gap-8 md:grid-cols-3">
           <div className="p-6 rounded-lg shadow bg-white">
             <h3 className="text-xl font-semibold text-[#2563eb] mb-2">
-              Conversión Inteligente
+              {t('landing.features.smartConversion.title')}
             </h3>
             <p className="text-[#64748b]">
-              Transforma tus archivos a múltiples formatos con IA.
+              {t('landing.features.smartConversion.desc')}
             </p>
           </div>
           <div className="p-6 rounded-lg shadow bg-white">
             <h3 className="text-xl font-semibold text-[#2563eb] mb-2">
-              Diseño Intuitivo
+              {t('landing.features.intuitiveDesign.title')}
             </h3>
             <p className="text-[#64748b]">
-              Interfaz sencilla y optimizada para tu flujo de trabajo.
+              {t('landing.features.intuitiveDesign.desc')}
             </p>
           </div>
           <div className="p-6 rounded-lg shadow bg-white">
             <h3 className="text-xl font-semibold text-[#2563eb] mb-2">
-              Soporte Multiplataforma
+              {t('landing.features.multiplatformSupport.title')}
             </h3>
             <p className="text-[#64748b]">
-              Disponible en todos tus dispositivos favoritos.
+              {t('landing.features.multiplatformSupport.desc')}
             </p>
           </div>
         </div>
@@ -49,47 +51,47 @@ export default function LandingPage() {
       {/* Pricing Section */}
       <section className="bg-[#f8fafc] py-16 px-4">
         <h2 className="text-3xl font-semibold text-center text-[#1e40af] mb-12">
-          Precios
+          {t('landing.pricingTitle')}
         </h2>
         <div className="max-w-5xl mx-auto grid gap-8 md:grid-cols-3">
           <div className="p-6 border rounded-lg">
             <h3 className="text-xl font-semibold text-[#2563eb] mb-4">
-              Gratis
+              {t('landing.pricing.free.title')}
             </h3>
-            <p className="text-[#64748b] mb-6">Funcionalidades básicas sin costo.</p>
+            <p className="text-[#64748b] mb-6">{t('landing.pricing.free.desc')}</p>
             <Link
               href="/app"
               className="block text-center bg-[#2563eb] text-white py-2 px-4 rounded"
             >
-              Comenzar
+              {t('landing.pricing.free.cta')}
             </Link>
           </div>
           <div className="p-6 border-2 border-[#2563eb] rounded-lg">
             <h3 className="text-xl font-semibold text-[#2563eb] mb-4">
-              Pro
+              {t('landing.pricing.pro.title')}
             </h3>
             <p className="text-[#64748b] mb-6">
-              Conversión ilimitada y funciones avanzadas.
+              {t('landing.pricing.pro.desc')}
             </p>
             <Link
               href="/app"
               className="block text-center bg-[#3b82f6] text-white py-2 px-4 rounded"
             >
-              Elegir Pro
+              {t('landing.pricing.pro.cta')}
             </Link>
           </div>
           <div className="p-6 border rounded-lg">
             <h3 className="text-xl font-semibold text-[#2563eb] mb-4">
-              Empresa
+              {t('landing.pricing.enterprise.title')}
             </h3>
             <p className="text-[#64748b] mb-6">
-              Soluciones personalizadas para equipos.
+              {t('landing.pricing.enterprise.desc')}
             </p>
             <Link
               href="/app"
               className="block text-center bg-[#2563eb] text-white py-2 px-4 rounded"
             >
-              Contáctanos
+              {t('landing.pricing.enterprise.cta')}
             </Link>
           </div>
         </div>
@@ -98,13 +100,13 @@ export default function LandingPage() {
       {/* CTA Section */}
       <section className="text-center py-20 bg-[#1e293b] text-white px-4">
         <h2 className="text-3xl font-bold mb-6">
-          ¿Listo para transformar tu contenido?
+          {t('landing.ctaTitle')}
         </h2>
         <Link
           href="/app"
           className="inline-block bg-[#3b82f6] hover:bg-[#2563eb] text-white px-8 py-3 rounded-lg font-medium"
         >
-          Ir a la App
+          {t('landing.ctaButton')}
         </Link>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- add `react-i18next` with initial translations for English and Spanish
- wrap app with `I18nextProvider`
- add language selector and translate key landing page content

## Testing
- `npm test` *(fails: Cannot find module '../../../App' imported from '/workspace/AncloraMetaform/frontend/src/components/__tests__/App.test.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_689d75ace14c832093205ca37c587feb