### PR TITLE
feat: add encoding normalization utilities

### DIFF
--- a/backend/requirements-test.txt
+++ b/backend/requirements-test.txt
@@ -4,3 +4,4 @@ pytest-cov==6.0.0
 python-docx>=0.8.11
 fpdf2>=2.7
 pypdf==6.0.0
+chardet>=5.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,3 +18,4 @@ Werkzeug==3.1.3
 python-docx>=0.8.11
 fpdf2>=2.7
 pypdf==6.0.0
+chardet>=5.0.0

--- a/backend/src/nexus/__init__.py
+++ b/backend/src/nexus/__init__.py
@@ -1,0 +1,13 @@
+from .encoding_normalizer import (
+    detect_encoding,
+    repair_mojibake,
+    normalize_to_utf8,
+    undo_normalization,
+)
+
+__all__ = [
+    "detect_encoding",
+    "repair_mojibake",
+    "normalize_to_utf8",
+    "undo_normalization",
+]

--- a/backend/src/nexus/cli.py
+++ b/backend/src/nexus/cli.py
@@ -1,0 +1,41 @@
+import argparse
+from pathlib import Path
+
+from .encoding_normalizer import detect_encoding, normalize_to_utf8, repair_mojibake, undo_normalization
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Normalize file encodings to UTF-8")
+    parser.add_argument("paths", nargs="+", help="Files to process")
+    parser.add_argument("--bom", action="store_true", help="Write UTF-8 BOM")
+    parser.add_argument("--dry-run", action="store_true", help="Preview changes without modifying files")
+    parser.add_argument("--undo", action="store_true", help="Restore files from backups")
+    args = parser.parse_args()
+
+    for path_str in args.paths:
+        path = Path(path_str)
+        if args.undo:
+            success = undo_normalization(path)
+            if success:
+                print(f"Restored {path}")
+            else:
+                print(f"No backup for {path}")
+            continue
+
+        if args.dry_run:
+            raw = path.read_bytes()
+            enc = detect_encoding(raw)
+            text = raw.decode(enc or "utf-8", errors="ignore")
+            repaired = repair_mojibake(text)
+            target = "utf-8-sig" if args.bom else "utf-8"
+            print(f"{path}: {enc} -> {target}")
+            if repaired != text:
+                print("  (mojibake repaired)")
+            continue
+
+        normalize_to_utf8(path, bom=args.bom)
+        print(f"Normalized {path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/backend/src/nexus/encoding_normalizer.py
+++ b/backend/src/nexus/encoding_normalizer.py
@@ -1,0 +1,89 @@
+import json
+import re
+from pathlib import Path
+from datetime import datetime
+
+import chardet
+
+MOJIBAKE_RE = re.compile(r"Ã|Â|â€")
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+LOG_DIR = BASE_DIR / "logs" / "encoding"
+LOG_FILE = LOG_DIR / "encoding_normalizer.log"
+
+
+def detect_encoding(raw_bytes: bytes) -> str:
+    """Detect the encoding of the given raw bytes using chardet."""
+    result = chardet.detect(raw_bytes)
+    return result.get("encoding") or "utf-8"
+
+
+def repair_mojibake(text: str) -> str:
+    """Attempt to repair common mojibake issues."""
+    if MOJIBAKE_RE.search(text):
+        try:
+            return text.encode("latin1").decode("utf-8")
+        except Exception:
+            return text
+    return text
+
+
+def _log_entry(entry: dict) -> None:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    with LOG_FILE.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+
+def normalize_to_utf8(path, bom: bool = False) -> dict:
+    """Normalize the file at ``path`` to UTF-8 encoding.
+
+    Parameters
+    ----------
+    path: str or Path
+        Path to the file to normalize.
+    bom: bool
+        If True, write a UTF-8 BOM.
+
+    Returns
+    -------
+    dict
+        The log entry describing the normalization.
+    """
+    file_path = Path(path)
+    raw = file_path.read_bytes()
+    detected = detect_encoding(raw)
+    text = raw.decode(detected or "utf-8", errors="ignore")
+    repaired = repair_mojibake(text)
+    encoded = repaired.encode("utf-8-sig" if bom else "utf-8")
+
+    backup_path = file_path.with_suffix(file_path.suffix + ".bak")
+    backup_path.write_bytes(raw)
+    file_path.write_bytes(encoded)
+
+    entry = {
+        "path": str(file_path),
+        "backup": str(backup_path),
+        "from": detected,
+        "to": "utf-8-sig" if bom else "utf-8",
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+    }
+    _log_entry(entry)
+    return entry
+
+
+def undo_normalization(path) -> bool:
+    """Restore a file from its backup if available."""
+    file_path = Path(path)
+    backup_path = file_path.with_suffix(file_path.suffix + ".bak")
+    if not backup_path.exists():
+        return False
+    original = backup_path.read_bytes()
+    file_path.write_bytes(original)
+    backup_path.unlink()
+    entry = {
+        "path": str(file_path),
+        "action": "undo",
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+    }
+    _log_entry(entry)
+    return True

--- a/tests/unit/test_encoding_normalizer.py
+++ b/tests/unit/test_encoding_normalizer.py
@@ -1,0 +1,38 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from src.nexus.encoding_normalizer import (
+    detect_encoding,
+    normalize_to_utf8,
+    repair_mojibake,
+)
+
+
+def test_detect_encoding():
+    data = "áéíóú".encode("utf-16")
+    assert detect_encoding(data).lower().startswith("utf-16")
+
+
+def test_repair_mojibake():
+    bad = "España".encode("utf-8").decode("latin1")  # -> 'EspaÃ±a'
+    assert repair_mojibake(bad) == "España"
+
+
+def test_normalize_to_utf8(tmp_path):
+    file_path = tmp_path / "sample.txt"
+    file_path.write_bytes("áéíóú".encode("utf-16"))
+
+    # ensure log clean
+    log_file = Path(__file__).resolve().parents[2] / "backend/logs/encoding/encoding_normalizer.log"
+    if log_file.exists():
+        log_file.unlink()
+
+    entry = normalize_to_utf8(file_path)
+    assert file_path.read_text(encoding="utf-8") == "áéíóú"
+    assert Path(entry["backup"]).exists()
+
+    with log_file.open() as fh:
+        last = json.loads(fh.readlines()[-1])
+    assert last["path"] == str(file_path)


### PR DESCRIPTION
## Summary
- add encoding detection, mojibake repair and normalization with logging
- expose CLI for normalization with dry-run and undo support
- cover encoding normalization features with unit tests

## Testing
- `pytest tests/unit/test_encoding_normalizer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d9efb43688320af975095704c6b4c