### PR TITLE
Normalize text inputs before conversion

### DIFF
--- a/backend/requirements-test.txt
+++ b/backend/requirements-test.txt
@@ -4,3 +4,4 @@ pytest-cov==6.0.0
 python-docx>=0.8.11
 fpdf2>=2.7
 pypdf==6.0.0
+ftfy==6.2.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,3 +18,4 @@ Werkzeug==3.1.3
 python-docx>=0.8.11
 fpdf2>=2.7
 pypdf==6.0.0
+ftfy==6.2.0

--- a/backend/src/models/conversion.py
+++ b/backend/src/models/conversion.py
@@ -10,6 +10,49 @@ from fpdf import FPDF
 from PIL import Image, ImageDraw
 from pypdf import PdfReader
 
+# Para normalización de texto
+try:
+    from ftfy import fix_text
+except Exception:  # pragma: no cover - ftfy es opcional en tiempo de ejecución
+    fix_text = None
+
+
+# Extensiones consideradas texto plano
+TEXT_EXTENSIONS = {
+    'txt', 'md', 'html', 'rtf', 'csv', 'tex', 'odt', 'svg'
+}
+
+
+def normalize_to_utf8(path: str):
+    """Normaliza un archivo de texto a UTF-8.
+
+    Si el archivo contiene bytes nulos se considera irrecuperable
+    (unsalvageable). Si la decodificación falla se intenta reparar
+    utilizando latin-1 y ftfy si está disponible.
+    """
+
+    with open(path, 'rb') as f:
+        data = f.read()
+
+    if b"\x00" in data:
+        return False, "unsalvageable"
+
+    try:
+        text = data.decode('utf-8')
+    except UnicodeDecodeError:
+        text = data.decode('latin-1', errors='replace')
+
+    if fix_text:
+        try:
+            text = fix_text(text)
+        except Exception:
+            pass
+
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(text)
+
+    return True, "normalized"
+
 # Importar el motor de conversión existente
 # (Aquí integraremos el motor que ya tienes implementado)
 # (Aquí integraremos el motor que ya tienes implementado)
@@ -166,7 +209,12 @@ class ConversionEngine:
     def convert_file(self, input_path, output_path, source_format, target_format):
         """Realiza la conversión de archivo"""
         try:
-            source = source_format.lower()
+            source = source_format.lower().replace('.', '')
+            if source in TEXT_EXTENSIONS:
+                ok, msg = normalize_to_utf8(input_path)
+                if not ok:
+                    return False, msg
+
             target = target_format.lower()
             method = self.conversion_methods.get((source, target))
             if method:

--- a/tests/unit/test_conversion_engine.py
+++ b/tests/unit/test_conversion_engine.py
@@ -56,3 +56,25 @@ def test_conversion_engine(source_ext, target_ext):
         result, msg = conversion_engine.convert_file(input_path, output_path, source_ext, target_ext)
         assert result, msg
         assert os.path.exists(output_path)
+
+
+def test_mojibake_normalization_and_conversion():
+    """El motor debe reparar mojibake antes de convertir."""
+    with tempfile.TemporaryDirectory() as tmp:
+        input_path = os.path.join(tmp, 'in.txt')
+        output_path = os.path.join(tmp, 'out.pdf')
+
+        # Texto original con carácter especial
+        original = 'señor'
+        # Simular mojibake: bytes UTF-8 mal interpretados como latin-1
+        mojibake = original.encode('utf-8').decode('latin-1')
+        with open(input_path, 'w', encoding='utf-8') as f:
+            f.write(mojibake)
+
+        result, msg = conversion_engine.convert_file(input_path, output_path, 'txt', 'pdf')
+        assert result, msg
+        assert os.path.exists(output_path)
+
+        # Verificar que el archivo haya sido normalizado
+        with open(input_path, encoding='utf-8') as f:
+            assert original in f.read()


### PR DESCRIPTION
## Summary
- normalize text-based source files to UTF-8 before conversion
- flag files containing null bytes as unsalvageable
- test mojibake repair and subsequent conversion

## Testing
- `pip install -r backend/requirements-test.txt`
- `pytest tests/unit/test_conversion_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d9efda3948320a2de802b31107d95