### PR TITLE
Add multi-step conversion path with intermediate logging

### DIFF
--- a/backend/src/models/conversion.py
+++ b/backend/src/models/conversion.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import uuid
 import shutil
+from collections import deque
 
 from docx import Document
 from fpdf import FPDF
@@ -160,8 +161,41 @@ class ConversionEngine:
                 'Para documentos, PDF mantiene la calidad',
                 'Para web, considera optimización de tamaño'
             ]
-        
+
         return analysis
+
+    def find_conversion_path(self, src_format: str, dst_format: str):
+        """Busca una ruta de conversión usando BFS con hasta dos intermediarios.
+
+        Devuelve una lista de formatos que representa el camino desde src_format
+        hasta dst_format, inclusive. Si no se encuentra una ruta válida dentro
+        del límite de profundidad, devuelve None.
+        """
+        src = src_format.lower()
+        dst = dst_format.lower()
+
+        if src == dst:
+            return [src]
+
+        max_depth = 3  # número máximo de pasos (edges): src -> a -> b -> dst
+        queue = deque([(src, [src])])
+        visited = {src}
+
+        while queue:
+            current, path = queue.popleft()
+            depth = len(path) - 1
+            if depth >= max_depth:
+                continue
+            for neighbor in self.supported_conversions.get(current, {}):
+                if neighbor in visited:
+                    continue
+                new_path = path + [neighbor]
+                if neighbor == dst:
+                    return new_path
+                visited.add(neighbor)
+                queue.append((neighbor, new_path))
+
+        return None
 
     def convert_file(self, input_path, output_path, source_format, target_format):
         """Realiza la conversión de archivo"""
@@ -171,7 +205,42 @@ class ConversionEngine:
             method = self.conversion_methods.get((source, target))
             if method:
                 return method(input_path, output_path)
-            return False, f"Conversión {source_format} → {target_format} no implementada aún"
+
+            path = self.find_conversion_path(source, target)
+            if not path:
+                return False, f"Conversión {source_format} → {target_format} no implementada aún"
+
+            logs = []
+            temp_files = []
+            current_input = input_path
+
+            try:
+                for i in range(len(path) - 1):
+                    src_fmt = path[i]
+                    dst_fmt = path[i + 1]
+                    step_method = self.conversion_methods.get((src_fmt, dst_fmt))
+                    if not step_method:
+                        return False, f"Conversión {src_fmt} → {dst_fmt} no implementada"
+
+                    if i == len(path) - 2:
+                        current_output = output_path
+                    else:
+                        fd, current_output = tempfile.mkstemp(suffix=f'.{dst_fmt}')
+                        os.close(fd)
+                        temp_files.append(current_output)
+
+                    success, msg = step_method(current_input, current_output)
+                    logs.append(f"{src_fmt}->{dst_fmt}: {msg}")
+                    if not success:
+                        return False, f"Fallo en {src_fmt}->{dst_fmt}: {msg}"
+
+                    current_input = current_output
+
+                return True, " | ".join(logs)
+            finally:
+                for tmp in temp_files:
+                    if os.path.exists(tmp):
+                        os.remove(tmp)
         except Exception as e:
             return False, f"Error durante la conversión: {str(e)}"
 

--- a/tests/unit/test_conversion_engine.py
+++ b/tests/unit/test_conversion_engine.py
@@ -56,3 +56,15 @@ def test_conversion_engine(source_ext, target_ext):
         result, msg = conversion_engine.convert_file(input_path, output_path, source_ext, target_ext)
         assert result, msg
         assert os.path.exists(output_path)
+
+
+def test_svg_to_jpg_via_png():
+    """Verifica que SVG se convierte a JPG usando una ruta intermedia PNG."""
+    with tempfile.TemporaryDirectory() as tmp:
+        input_path = os.path.join(tmp, 'in.svg')
+        output_path = os.path.join(tmp, 'out.jpg')
+        create_sample_file('svg', input_path)
+        result, msg = conversion_engine.convert_file(input_path, output_path, 'svg', 'jpg')
+        assert result, msg
+        assert os.path.exists(output_path)
+        assert 'svg->png' in msg and 'png->jpg' in msg


### PR DESCRIPTION
## Summary
- implement BFS-based `find_conversion_path` allowing up to two intermediate formats
- extend `convert_file` to chain conversions along discovered path and log each step
- add unit test verifying SVG→JPG conversion via SVG→PNG→JPG

## Testing
- `pytest tests/unit/test_conversion_engine.py::test_conversion_engine tests/unit/test_conversion_engine.py::test_svg_to_jpg_via_png -q`


------
https://chatgpt.com/codex/tasks/task_e_689d9efe47708320aace5bb990a016f7