### PR TITLE
feat: add file classification

### DIFF
--- a/backend/src/models/conversion.py
+++ b/backend/src/models/conversion.py
@@ -10,6 +10,35 @@ from fpdf import FPDF
 from PIL import Image, ImageDraw
 from pypdf import PdfReader
 
+
+def validate_and_classify(file_path):
+    """Clasifica un archivo en valid, salvageable o unsalvageable"""
+    if not os.path.exists(file_path) or os.path.isdir(file_path):
+        return "unsalvageable"
+
+    try:
+        with open(file_path, "rb") as f:
+            data = f.read()
+    except OSError:
+        return "unsalvageable"
+
+    if not data:
+        return "unsalvageable"
+
+    try:
+        text = data.decode("utf-8")
+        # Si contiene caracteres de reemplazo, es recuperable
+        if "\ufffd" in text:
+            return "salvageable"
+        return "valid"
+    except UnicodeDecodeError:
+        text = data.decode("utf-8", errors="replace")
+        if not text:
+            return "unsalvageable"
+        replacements = text.count("\ufffd")
+        ratio = replacements / len(text)
+        return "salvageable" if ratio < 0.3 else "unsalvageable"
+
 # Importar el motor de conversión existente
 # (Aquí integraremos el motor que ya tienes implementado)
 # (Aquí integraremos el motor que ya tienes implementado)

--- a/tests/unit/test_conversion_classifier.py
+++ b/tests/unit/test_conversion_classifier.py
@@ -1,0 +1,27 @@
+import os
+import tempfile
+from src.models.conversion import validate_and_classify
+
+
+def write_bytes(path, data):
+    with open(path, 'wb') as f:
+        f.write(data)
+
+
+def test_validate_and_classify_valid(tmp_path):
+    p = tmp_path / "valid.txt"
+    p.write_text("hola mundo", encoding="utf-8")
+    assert validate_and_classify(str(p)) == "valid"
+
+
+def test_validate_and_classify_mojibake(tmp_path):
+    p = tmp_path / "mojibake.txt"
+    data = "café".encode("latin-1")  # bytes invalidos en utf-8
+    write_bytes(str(p), data)
+    assert validate_and_classify(str(p)) == "salvageable"
+
+
+def test_validate_and_classify_corrupt(tmp_path):
+    p = tmp_path / "corrupt.bin"
+    write_bytes(str(p), b"\xff\x00" * 50)
+    assert validate_and_classify(str(p)) == "unsalvageable"


### PR DESCRIPTION
## Summary
- add `validate_and_classify` helper to flag corrupt or salvageable files
- expose classification in `/analyze-file` and show it in UniversalConverter UI
- test classifier behavior on valid, mojibake, and corrupt inputs

## Testing
- `pytest tests/unit -q`
- `npm test` *(fails: "@vitejs/plugin-react" resolved to an ESM file. ESM file cannot be loaded by `require`)*

------
https://chatgpt.com/codex/tasks/task_e_689d9f03b4488320915edfd7d6c50998