### PR TITLE
feat: improve converter accessibility

### DIFF
--- a/frontend/src/components/UniversalConverter.tsx
+++ b/frontend/src/components/UniversalConverter.tsx
@@ -19,6 +19,7 @@ interface QueueItem {
 export const UniversalConverter: React.FC = () => {
   const [queue, setQueue] = useState<QueueItem[]>([]);
   const [processing, setProcessing] = useState(false);
+  const [liveMessage, setLiveMessage] = useState('');
   const classifyFile = useCallback(async (file: File) => {
     try {
       const text = await file.text();
@@ -111,6 +112,7 @@ export const UniversalConverter: React.FC = () => {
       );
       delete timersRef.current[item.id];
       setProcessing(false);
+      setLiveMessage(`Conversión completada para ${item.file.name}`);
     }, 2000);
 
     timersRef.current[item.id] = { interval, timeout };
@@ -123,13 +125,15 @@ export const UniversalConverter: React.FC = () => {
       clearTimeout(timer.timeout);
       delete timersRef.current[id];
     }
-    const wasProcessing = queue.find(q => q.id === id)?.status === 'processing';
+    const cancelledItem = queue.find(q => q.id === id);
+    const wasProcessing = cancelledItem?.status === 'processing';
     setQueue(prev =>
       prev.map(q => (q.id === id ? { ...q, status: 'cancelled' } : q))
     );
     if (wasProcessing) {
       setProcessing(false);
     }
+    setLiveMessage(`Conversión cancelada para ${cancelledItem?.file.name || 'archivo'}`);
   };
 
   const moveItem = (id: string, direction: 'up' | 'down') => {
@@ -146,6 +150,9 @@ export const UniversalConverter: React.FC = () => {
 
   return (
     <div className="space-y-6">
+      <div aria-live="assertive" className="sr-only">
+        {liveMessage}
+      </div>
       <h1 className="text-3xl font-bold text-center">Conversor Inteligente</h1>
       <FileUploader onFileSelect={handleFileSelect} isLoading={processing} multiple>
         <div className="p-6 border-2 border-dashed rounded-md text-center">
@@ -164,12 +171,19 @@ export const UniversalConverter: React.FC = () => {
                 <span className="text-sm">{item.progress}%</span>
               </div>
               <p className="text-xs mb-1">Clasificación: {item.classification}</p>
-              <div className="w-full bg-gray-200 h-2 rounded">
                 <div
-                  className="bg-green-500 h-2 rounded"
-                  style={{ width: `${item.progress}%` }}
-                ></div>
-              </div>
+                  className="w-full bg-gray-200 h-2 rounded"
+                  role="progressbar"
+                  aria-label={`Progreso de conversión de ${item.file.name}`}
+                  aria-valuenow={item.progress}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                >
+                  <div
+                    className="bg-green-500 h-2 rounded"
+                    style={{ width: `${item.progress}%` }}
+                  ></div>
+                </div>
               <div className="flex gap-2">
                 <button
                   onClick={() => cancelConversion(item.id)}


### PR DESCRIPTION
## Summary
- add progressbar with aria attributes
- announce conversion completion or cancel with aria-live

## Testing
- `pytest` *(fails: No such file / missing modules)*
- `npm test` *(fails: unresolved imports and test suite issues)*
- `npm run lint` *(fails: requires interactive configuration)*
- `npx --yes @axe-core/cli https://example.com` *(no output)*
- `npx --yes lighthouse https://example.com --quiet --chrome-flags="--headless" --output=json --output-path=/tmp/lighthouse.json` *(fails: CHROME_PATH not set)*

------
https://chatgpt.com/codex/tasks/task_e_689fd544801c8320bd0b58a00e7160d4