### PR TITLE
feat: add accessible modal

### DIFF
--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useRef } from 'react';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (isOpen && dialog) {
+      // Save the element that triggered the modal
+      lastFocusedElementRef.current = document.activeElement as HTMLElement;
+
+      const focusableSelectors =
+        'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+      const focusable = dialog.querySelectorAll<HTMLElement>(focusableSelectors);
+      focusable[0]?.focus();
+
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          onClose();
+          return;
+        }
+        if (e.key === 'Tab' && focusable.length > 0) {
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+          if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          } else if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        }
+      };
+
+      dialog.addEventListener('keydown', handleKeyDown);
+      return () => {
+        dialog.removeEventListener('keydown', handleKeyDown);
+      };
+    }
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen && lastFocusedElementRef.current) {
+      lastFocusedElementRef.current.focus();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="modal-backdrop">
+      <div ref={dialogRef} role="dialog" aria-modal="true" className="modal-content">
+        <button onClick={onClose} aria-label="Cerrar" className="modal-close">
+          ×
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/frontend/src/components/__tests__/Modal.test.tsx
+++ b/frontend/src/components/__tests__/Modal.test.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, afterEach } from 'vitest';
+import { Modal } from '../Modal';
+
+const ModalWrapper = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open Modal</button>
+      <Modal isOpen={open} onClose={() => setOpen(false)}>
+        <input placeholder="First" />
+        <button>Second</button>
+      </Modal>
+    </>
+  );
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Modal accessibility', () => {
+  it('traps focus and restores trigger focus on close', async () => {
+    render(<ModalWrapper />);
+    const trigger = screen.getByText('Open Modal');
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    const closeButton = screen.getByLabelText('Cerrar');
+    expect(closeButton).toHaveFocus();
+
+    // Manually move focus through elements
+    const firstInput = screen.getByPlaceholderText('First');
+    firstInput.focus();
+    const secondButton = screen.getByText('Second');
+    secondButton.focus();
+
+    // Tab from last element should wrap to first (close button)
+    fireEvent.keyDown(secondButton, { key: 'Tab' });
+    expect(closeButton).toHaveFocus();
+
+    // Close with Escape
+    fireEvent.keyDown(closeButton, { key: 'Escape' });
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(trigger).toHaveFocus();
+  });
+
+  it('provides an accessible close button', () => {
+    render(<ModalWrapper />);
+    fireEvent.click(screen.getByText('Open Modal'));
+    expect(screen.getByLabelText('Cerrar')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable Modal component with focus trapping and escape closing
- restore focus to trigger and expose accessible close button
- cover modal accessibility with new unit tests

## Testing
- `npm test` *(fails: 14 failed, 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689fd544dca883208ea93ab6e42194db