### PR TITLE
feat: improve accessibility for auth forms

### DIFF
--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -208,21 +208,22 @@ export const LoginForm: React.FC = () => {
         <form onSubmit={handleSubmit} className="space-y-6">
           <div className="card p-6 space-y-4">
             {!isLogin && (
-              <div className="input-group">
-                <label htmlFor="full_name" className="input-label">
-                  Nombre Completo
-                </label>
-                <input
-                  id="full_name"
-                  name="full_name"
-                  type="text"
-                  required={!isLogin}
-                  value={formData.full_name}
-                  onChange={handleChange}
-                  className="input"
-                  placeholder="Tu nombre completo"
-                />
-              </div>
+            <div className="input-group">
+              <label htmlFor="full_name" className="input-label">
+                Nombre Completo
+              </label>
+              <input
+                id="full_name"
+                name="full_name"
+                type="text"
+                required={!isLogin}
+                value={formData.full_name}
+                onChange={handleChange}
+                className="input"
+                placeholder="Tu nombre completo"
+                aria-describedby={error ? 'auth-error' : undefined}
+              />
+            </div>
             )}
 
             <div className="input-group">
@@ -238,6 +239,7 @@ export const LoginForm: React.FC = () => {
                 onChange={handleChange}
                 className="input"
                 placeholder="tu@email.com"
+                aria-describedby={error ? 'auth-error' : undefined}
               />
             </div>
 
@@ -254,11 +256,17 @@ export const LoginForm: React.FC = () => {
                 onChange={handleChange}
                 className="input"
                 placeholder="••••••••"
+                aria-describedby={error ? 'auth-error' : undefined}
               />
             </div>
 
             {error && (
-              <div className="bg-danger/10 border border-danger/30 rounded-lg p-3">
+              <div
+                id="auth-error"
+                role="alert"
+                aria-live="polite"
+                className="bg-danger/10 border border-danger/30 rounded-lg p-3"
+              >
                 <p className="text-danger text-sm">{error}</p>
               </div>
             )}

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -114,7 +114,12 @@ export const Login: React.FC<LoginProps> = ({
 
         {/* Error Message */}
         {error && (
-          <div className="login-error">
+          <div
+            id="login-error"
+            role="alert"
+            aria-live="polite"
+            className="login-error"
+          >
             <span className="error-icon">⚠️</span>
             {error}
           </div>
@@ -158,6 +163,7 @@ export const Login: React.FC<LoginProps> = ({
               className="form-input"
               placeholder="tu@email.com"
               autoComplete="email"
+              aria-describedby={error ? 'login-error' : undefined}
             />
           </div>
 
@@ -178,6 +184,7 @@ export const Login: React.FC<LoginProps> = ({
                 placeholder="••••••••"
                 autoComplete="current-password"
                 minLength={6}
+                aria-describedby={error ? 'login-error' : undefined}
               />
               <button
                 type="button"

--- a/frontend/src/components/Register.tsx
+++ b/frontend/src/components/Register.tsx
@@ -157,7 +157,12 @@ export const Register: React.FC<RegisterProps> = ({
 
         {/* Error Message */}
         {error && (
-          <div className="register-error">
+          <div
+            id="register-error"
+            role="alert"
+            aria-live="polite"
+            className="register-error"
+          >
             <span className="error-icon">⚠️</span>
             {error}
           </div>
@@ -190,35 +195,37 @@ export const Register: React.FC<RegisterProps> = ({
               <label htmlFor="fullName" className="form-label">
                 Nombre completo
               </label>
-              <input
-                type="text"
-                id="fullName"
-                name="fullName"
-                value={formData.fullName}
-                onChange={handleInputChange}
-                required
-                disabled={isLoading}
-                className="form-input"
-                placeholder="Tu nombre"
-                autoComplete="name"
-              />
+            <input
+              type="text"
+              id="fullName"
+              name="fullName"
+              value={formData.fullName}
+              onChange={handleInputChange}
+              required
+              disabled={isLoading}
+              className="form-input"
+              placeholder="Tu nombre"
+              autoComplete="name"
+              aria-describedby={error ? 'register-error' : undefined}
+            />
             </div>
 
             <div className="form-group">
               <label htmlFor="company" className="form-label">
                 Empresa (opcional)
               </label>
-              <input
-                type="text"
-                id="company"
-                name="company"
-                value={formData.company}
-                onChange={handleInputChange}
-                disabled={isLoading}
-                className="form-input"
-                placeholder="Tu empresa"
-                autoComplete="organization"
-              />
+            <input
+              type="text"
+              id="company"
+              name="company"
+              value={formData.company}
+              onChange={handleInputChange}
+              disabled={isLoading}
+              className="form-input"
+              placeholder="Tu empresa"
+              autoComplete="organization"
+              aria-describedby={error ? 'register-error' : undefined}
+            />
             </div>
           </div>
 
@@ -237,6 +244,7 @@ export const Register: React.FC<RegisterProps> = ({
               className="form-input"
               placeholder="tu@email.com"
               autoComplete="email"
+              aria-describedby={error ? 'register-error' : undefined}
             />
           </div>
 
@@ -257,6 +265,7 @@ export const Register: React.FC<RegisterProps> = ({
                 placeholder="••••••••"
                 autoComplete="new-password"
                 minLength={6}
+                aria-describedby={error ? 'register-error' : undefined}
               />
               <button
                 type="button"
@@ -305,21 +314,35 @@ export const Register: React.FC<RegisterProps> = ({
               className="form-input"
               placeholder="••••••••"
               autoComplete="new-password"
+              aria-describedby={`${error ? 'register-error ' : ''}${
+                formData.confirmPassword && formData.password !== formData.confirmPassword
+                  ? 'confirmPassword-error'
+                  : ''
+              }`.trim() || undefined}
             />
             {formData.confirmPassword && formData.password !== formData.confirmPassword && (
-              <span className="field-error">Las contraseñas no coinciden</span>
+              <span
+                id="confirmPassword-error"
+                role="alert"
+                aria-live="polite"
+                className="field-error"
+              >
+                Las contraseñas no coinciden
+              </span>
             )}
           </div>
 
           {/* Marketing Consent */}
           <div className="form-group checkbox-group">
-            <label className="checkbox-label">
+            <label htmlFor="marketingConsent" className="checkbox-label">
               <input
                 type="checkbox"
+                id="marketingConsent"
                 name="marketingConsent"
                 checked={formData.marketingConsent}
                 onChange={handleInputChange}
                 className="checkbox-input"
+                aria-describedby={error ? 'register-error' : undefined}
               />
               <span className="checkbox-text">
                 Quiero recibir actualizaciones y ofertas especiales por email


### PR DESCRIPTION
## Summary
- add polite alert containers for auth form feedback
- link inputs to labels and error messages via `aria-describedby`
- ensure registration checkbox is properly labeled

## Testing
- `npm test` *(fails: 14 failed, 2 passed)*
- `npm run lint` *(unable to run: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689fd545ff3083208f49808cd995b291