### PR TITLE
feat: add high contrast theme support

### DIFF
--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useAuth } from '../../auth/AuthContext';
 import { useTranslation } from 'react-i18next';
+import { useTheme } from '../../theme/ThemeProvider';
 
 
 interface HeaderProps {
@@ -10,6 +11,7 @@ interface HeaderProps {
 export const Header: React.FC<HeaderProps> = ({ sidebarCollapsed }) => {
   const { user } = useAuth();
   const { t, i18n } = useTranslation();
+  const { highContrast, toggleHighContrast } = useTheme();
 
   const changeLanguage = (e: React.ChangeEvent<HTMLSelectElement>) => {
     i18n.changeLanguage(e.target.value);
@@ -48,6 +50,13 @@ export const Header: React.FC<HeaderProps> = ({ sidebarCollapsed }) => {
             <option value="es">ES</option>
             <option value="en">EN</option>
           </select>
+          <button
+            onClick={toggleHighContrast}
+            aria-pressed={highContrast}
+            className="bg-slate-800 text-white px-2 py-1 rounded"
+          >
+            {t('header.highContrast')}
+          </button>
           {/* Contador de créditos */}
           <div className="flex items-center gap-2 bg-blue-700/60 px-3 py-1 rounded-full text-white shadow-sm">
             <div className="w-2 h-2 bg-green-400 rounded-full"></div>

--- a/frontend/src/components/NewApp.tsx
+++ b/frontend/src/components/NewApp.tsx
@@ -6,6 +6,7 @@ import { MainLayout } from './Layout/MainLayout';
 import { NewConversorInteligente } from './NewConversorInteligente';
 import { ConversionHistory } from './ConversionHistory';
 import { CreditPurchase } from './CreditPurchase';
+import { ThemeProvider } from '../theme/ThemeProvider';
 import './styles/anclora-animations.css';
 
 // Componente placeholder para las secciones que aún no están implementadas
@@ -116,13 +117,15 @@ const AuthenticatedApp: React.FC = () => {
 // Componente principal de la aplicación
 const NewApp: React.FC = () => {
   return (
-    <AuthProvider>
-      <CreditProvider>
-        <ProtectedRoute>
-          <AuthenticatedApp />
-        </ProtectedRoute>
-      </CreditProvider>
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <CreditProvider>
+          <ProtectedRoute>
+            <AuthenticatedApp />
+          </ProtectedRoute>
+        </CreditProvider>
+      </AuthProvider>
+    </ThemeProvider>
   );
 };
 

--- a/frontend/src/i18n/translations.ts
+++ b/frontend/src/i18n/translations.ts
@@ -7,7 +7,8 @@ export const resources = {
         subtitle: 'Convert files with advanced artificial intelligence',
         credits: '{{count}} credits',
         defaultName: 'User',
-        defaultEmail: 'user@example.com'
+        defaultEmail: 'user@example.com',
+        highContrast: 'High Contrast'
       },
       landing: {
         heroTitle: 'Anclora Metaform',
@@ -58,7 +59,8 @@ export const resources = {
         subtitle: 'Convierte archivos con inteligencia artificial avanzada',
         credits: '{{count}} créditos',
         defaultName: 'Usuario',
-        defaultEmail: 'usuario@ejemplo.com'
+        defaultEmail: 'usuario@ejemplo.com',
+        highContrast: 'Contraste alto'
       },
       landing: {
         heroTitle: 'Anclora Metaform',

--- a/frontend/src/theme/ThemeProvider.tsx
+++ b/frontend/src/theme/ThemeProvider.tsx
@@ -1,0 +1,51 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+interface ThemeContextType {
+  highContrast: boolean;
+  toggleHighContrast: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType>({
+  highContrast: false,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  toggleHighContrast: () => {},
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [highContrast, setHighContrast] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('highContrast');
+    if (stored === 'true') {
+      setHighContrast(true);
+      document.documentElement.classList.add('hc');
+    }
+  }, []);
+
+  const toggleHighContrast = () => {
+    setHighContrast((prev) => {
+      const next = !prev;
+      const root = document.documentElement;
+      if (next) {
+        root.classList.add('hc');
+      } else {
+        root.classList.remove('hc');
+      }
+      localStorage.setItem('highContrast', String(next));
+      return next;
+    });
+  };
+
+  return (
+    <ThemeContext.Provider value={{ highContrast, toggleHighContrast }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -26,6 +26,12 @@ module.exports = {
           700: '#3E4C59',
           900: '#1F2933',
         },
+        // Paleta de alto contraste (ratio ≥ 7:1)
+        hc: {
+          background: '#000000', // Negro
+          foreground: '#FFFFFF', // Blanco
+          accent: '#FFD700', // Amarillo dorado
+        },
       },
       fontFamily: {
         inter: ['Inter', 'system-ui', 'sans-serif'],
@@ -70,5 +76,9 @@ module.exports = {
       transform: ['active'],
     },
   },
-  plugins: [],
+  plugins: [
+    function ({ addVariant }) {
+      addVariant('hc', '.hc &');
+    },
+  ],
 };


### PR DESCRIPTION
## Summary
- add ThemeProvider with high contrast flag that toggles `hc` class on `<html>`
- support `hc:` variant and accessible colors in Tailwind config
- toggle high contrast via button in header

## Testing
- `npm test` *(fails: Failed to resolve import "../Header" in Header.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689fd546f5bc83208de55927b4a6c1ea