### PR TITLE
feat: grid layout and container queries

### DIFF
--- a/frontend/BRANDING_GUIDE.md
+++ b/frontend/BRANDING_GUIDE.md
@@ -181,6 +181,20 @@ constructor() {
 }
 ```
 
+### **Utilidades de Layout Responsivo**
+
+- `AppLayout` emplea **CSS Grid** con áreas nombradas `sidebar`, `header` y `main` para organizar la aplicación.
+- Se habilitó el plugin `@tailwindcss/container-queries` para usar `@container` y adaptar las columnas según el ancho del contenedor.
+- Ejemplo:
+
+```jsx
+<section className="@container">
+  <div className="grid grid-cols-1 @[30rem]:grid-cols-2 @[48rem]:grid-cols-3">
+    {/* cards */}
+  </div>
+</section>
+```
+
 ## ✅ Checklist de Implementación
 
 ### **Componentes React**

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@tailwindcss/container-queries": "^0.1.1",
         "@tailwindcss/postcss": "^4.1.11",
         "@types/node": "^20",
         "@types/react": "^18.3.23",
@@ -3178,6 +3179,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@tailwindcss/container-queries": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz",
+      "integrity": "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.2.0"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.11.tgz",
@@ -3412,6 +3423,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,8 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "vite-plugin-pwa": "^0.20.5",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "@tailwindcss/container-queries": "^0.1.1"
   },
   "keywords": [
     "anclora",

--- a/frontend/src/components/Features.tsx
+++ b/frontend/src/components/Features.tsx
@@ -23,8 +23,8 @@ interface FeaturesProps {
 
 export const Features: React.FC<FeaturesProps> = ({ onStartConverting }) => {
   return (
-    <section className="w-full max-w-5xl mx-auto py-16 sm:py-24">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+    <section className="w-full max-w-5xl mx-auto py-16 sm:py-24 @container">
+        <div className="grid grid-cols-1 gap-8 @[30rem]:grid-cols-2 @[48rem]:grid-cols-3">
             <FeatureCard 
                 icon={<IconSparkles className="w-10 h-10 text-orange-500" />}
                 title={<>Es <span className="text-orange-500">fácil</span></>}

--- a/frontend/src/components/Layout/AppLayout.tsx
+++ b/frontend/src/components/Layout/AppLayout.tsx
@@ -3,13 +3,13 @@ import Sidebar from './Sidebar';
 import { Header } from './Header';
 import { CreditProvider, CreditBalance, CreditHistory } from '@/components/CreditSystem';
 
-interface MainLayoutProps {
+interface AppLayoutProps {
   children: React.ReactNode;
   activeTab: string;
   setActiveTab: (tab: string) => void;
 }
 
-export const MainLayout: React.FC<MainLayoutProps> = ({
+export const AppLayout: React.FC<AppLayoutProps> = ({
   children,
   activeTab,
   setActiveTab,
@@ -35,7 +35,14 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
   }, [activeTab]);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 relative overflow-hidden">
+    <div
+      className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 relative overflow-hidden grid"
+      style={{
+        gridTemplateColumns: 'auto 1fr',
+        gridTemplateRows: 'auto 1fr',
+        gridTemplateAreas: `'sidebar header' 'sidebar main'`,
+      }}
+    >
       {/* Fondo animado de ondas */}
       <div className="absolute inset-0 opacity-30 pointer-events-none">
         <div className="absolute inset-0 bg-gradient-to-br from-primary/20 via-secondary/10 to-primary/20 animate-pulse" />
@@ -44,44 +51,46 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
       </div>
 
       {/* Sidebar */}
-      <Sidebar
-        activeTab={activeTab}
-        setActiveTab={setActiveTab}
-        isCollapsed={sidebarCollapsed}
-        setIsCollapsed={setSidebarCollapsed}
-      />
+      <div style={{ gridArea: 'sidebar' }} className="relative z-20">
+        <Sidebar
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+          isCollapsed={sidebarCollapsed}
+          setIsCollapsed={setSidebarCollapsed}
+        />
+      </div>
 
       {/* Header */}
-      <Header />
+      <div style={{ gridArea: 'header' }} className="relative z-20">
+        <Header />
+      </div>
 
       {/* Capa negra en móvil al abrir menú */}
       {isMobile && !sidebarCollapsed && (
         <div
-          className="fixed inset-0 bg-black/50 z-30"
+          className="fixed inset-0 bg-black/50 z-10"
           onClick={() => setSidebarCollapsed(true)}
         />
       )}
 
       {/* Contenido principal */}
-        <main
-          ref={mainRef}
-          tabIndex={-1}
-          role="main"
-          aria-label="Contenido principal"
-          className={`
-            pt-16 min-h-screen relative z-10 transition-all duration-300 ease-in-out
-            ml-0 ${sidebarCollapsed ? 'md:ml-16' : 'md:ml-72'}
-          `}
-        >
+      <main
+        ref={mainRef}
+        tabIndex={-1}
+        role="main"
+        aria-label="Contenido principal"
+        style={{ gridArea: 'main' }}
+        className="pt-16 min-h-screen relative z-10 transition-all duration-300 ease-in-out p-6"
+      >
         {activeTab === 'Créditos' ? (
           <CreditProvider>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 p-6">
+            <div className="grid grid-cols-1 @[50rem]:grid-cols-2 gap-6">
               <CreditBalance />
               <CreditHistory />
             </div>
           </CreditProvider>
         ) : (
-          <div className="p-6">{children}</div>
+          <div>{children}</div>
         )}
       </main>
     </div>

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -3,11 +3,7 @@ import { useAuth } from '../../auth/AuthContext';
 import { useTranslation } from 'react-i18next';
 
 
-interface HeaderProps {
-  sidebarCollapsed: boolean;
-}
-
-export const Header: React.FC<HeaderProps> = ({ sidebarCollapsed }) => {
+export const Header: React.FC = () => {
   const { user } = useAuth();
   const { t, i18n } = useTranslation();
 
@@ -19,13 +15,7 @@ export const Header: React.FC<HeaderProps> = ({ sidebarCollapsed }) => {
     <header
       role="banner"
       aria-label={t('header.ariaLabel')}
-      className={`
-        fixed top-0 right-0 h-16
-        bg-gradient-to-br from-primary to-secondary
-        backdrop-blur-md shadow-md z-30 border-b border-white/10
-        transition-all duration-300 ease-in-out
-        left-0 ${sidebarCollapsed ? 'md:left-16' : 'md:left-72'}
-      `}
+      className="h-16 bg-gradient-to-br from-primary to-secondary backdrop-blur-md shadow-md z-30 border-b border-white/10"
     >
       <div className="flex items-center justify-between h-full px-6">
         {/* Título de la página actual */}

--- a/frontend/src/components/PopularConversions.tsx
+++ b/frontend/src/components/PopularConversions.tsx
@@ -116,8 +116,8 @@ export const PopularConversions: React.FC = () => {
                         })}
                     </ul>
                 </aside>
-                <main className="w-full md:w-3/4">
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <main className="w-full md:w-3/4 @container">
+                    <div className="grid grid-cols-1 gap-4 @[30rem]:grid-cols-2">
                         {activeInfo.conversions.map((conv, index) => (
                             <ConversionButton key={index} from={conv.from} to={conv.to} />
                         ))}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -70,5 +70,5 @@ module.exports = {
       transform: ['active'],
     },
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/container-queries')],
 };


### PR DESCRIPTION
## Summary
- Migrate application layout to CSS Grid with sidebar, header and main areas
- Enable Tailwind container queries and apply them to landing cards
- Document responsive layout utilities in branding guide

## Testing
- `npm test` *(fails: 14 failed, 2 passed)*
- `npm run lint` *(prompts for interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689fd54da26c8320ad1a808f87343be5