### PR TITLE
feat: add accessible icon wrapper

### DIFF
--- a/frontend/src/components/AccessibleIcon.tsx
+++ b/frontend/src/components/AccessibleIcon.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface AccessibleIconProps {
+  label: string;
+  children: React.ReactElement;
+}
+
+const AccessibleIcon: React.FC<AccessibleIconProps> = ({ label, children }) => (
+  <span role="img" aria-label={label} title={label}>
+    {React.cloneElement(children, { 'aria-hidden': true })}
+  </span>
+);
+
+export default AccessibleIcon;

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useAuth } from '../../auth/AuthContext';
 import { useTranslation } from 'react-i18next';
+import { ChevronDown } from 'lucide-react';
+import AccessibleIcon from '../AccessibleIcon';
 
 
 interface HeaderProps {
@@ -67,9 +69,9 @@ export const Header: React.FC<HeaderProps> = ({ sidebarCollapsed }) => {
                 {user?.email || t('header.defaultEmail')}
               </span>
             </div>
-            <svg className="w-4 h-4 text-white/50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-            </svg>
+            <AccessibleIcon label="Abrir menú">
+              <ChevronDown className="w-4 h-4 text-white/50" />
+            </AccessibleIcon>
           </div>
         </div>
       </div>

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import { ChevronLeft, ChevronRight, Home, FileText, Settings, User, CreditCard } from 'lucide-react';
+import AccessibleIcon from '../AccessibleIcon';
 
 interface SidebarProps {
   isCollapsed: boolean;
@@ -42,7 +43,15 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, setIsCollapsed }) => {
           onClick={() => setIsCollapsed(!isCollapsed)}
           className="p-1 rounded-lg hover:bg-gray-100 transition-colors"
         >
-          {isCollapsed ? <ChevronRight size={20} /> : <ChevronLeft size={20} />}
+          {isCollapsed ? (
+            <AccessibleIcon label="Expandir menú">
+              <ChevronRight size={20} />
+            </AccessibleIcon>
+          ) : (
+            <AccessibleIcon label="Contraer menú">
+              <ChevronLeft size={20} />
+            </AccessibleIcon>
+          )}
         </button>
       </div>
       
@@ -57,7 +66,9 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, setIsCollapsed }) => {
                   isCollapsed ? 'justify-center' : 'justify-start'
                 }`}
               >
-                <item.icon size={20} />
+                <AccessibleIcon label={item.label}>
+                  <item.icon size={20} />
+                </AccessibleIcon>
                 {!isCollapsed && <span className="ml-3">{item.label}</span>}
               </button>
             </li>

--- a/frontend/src/components/PopularConversions.tsx
+++ b/frontend/src/components/PopularConversions.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { IconAudio, IconVideo, IconImage, IconFile, IconArchive, IconPresentation, IconArrowRight, IconEbook } from '../frontend/components/Icons';
+import { IconAudio, IconVideo, IconImage, IconFile, IconArchive, IconPresentation, IconArrowRight, IconEbook } from './Icons';
 import { FileCategory } from '../utils/conversionMaps';
+import AccessibleIcon from './AccessibleIcon';
 
 type CategoryInfo = {
   name: string;
@@ -80,7 +81,9 @@ const displayCategories: FileCategory[] = ['ebook', 'audio', 'video', 'image', '
 const ConversionButton: React.FC<{from: string, to: string}> = ({ from, to }) => (
     <button className="popular-conversion-card w-full flex items-center justify-between">
         <span className="font-semibold">{from} a {to}</span>
-        <IconArrowRight className="w-5 h-5" />
+        <AccessibleIcon label="Ir">
+            <IconArrowRight className="w-5 h-5" />
+        </AccessibleIcon>
     </button>
 );
 

--- a/frontend/src/components/__tests__/AccessibleIcon.test.tsx
+++ b/frontend/src/components/__tests__/AccessibleIcon.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect } from 'vitest';
+import { Home } from 'lucide-react';
+import AccessibleIcon from '../AccessibleIcon';
+
+describe('AccessibleIcon', () => {
+  it('applies aria-label and title', () => {
+    render(
+      <AccessibleIcon label="Inicio">
+        <Home />
+      </AccessibleIcon>
+    );
+
+    const icon = screen.getByLabelText('Inicio');
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute('title', 'Inicio');
+  });
+});

--- a/frontend/src/components/__tests__/PopularConversions.test.tsx
+++ b/frontend/src/components/__tests__/PopularConversions.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import { PopularConversions } from '../../../components/PopularConversions';
+import { PopularConversions } from '../PopularConversions';
 
 describe('PopularConversions Component', () => {
     it('renders the component with the default category (ebook) active', () => {
@@ -37,5 +37,11 @@ describe('PopularConversions Component', () => {
 
         // And ebook conversions should be gone
         expect(screen.queryByRole('button', { name: /AZW a AZW3/i })).not.toBeInTheDocument();
+    });
+
+    it('renders arrow icons with accessible labels', () => {
+        render(<PopularConversions />);
+        const icon = screen.getAllByLabelText('Ir')[0];
+        expect(icon).toHaveAttribute('title', 'Ir');
     });
 });


### PR DESCRIPTION
## Summary
- add `AccessibleIcon` helper for consistent aria-label and title on icons
- wrap Sidebar, Header and conversion buttons icons with `AccessibleIcon`
- test that accessible labels are rendered

## Testing
- `npm test` *(fails: Found multiple elements with the role "button" and name `/Selecciona tu formato/i`)*
- `npx vitest run src/components/__tests__/AccessibleIcon.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689fd5577fe08320a95444f2797cf001