### PR TITLE
Add dependency manifests and installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ anclora-nexus/
 - Git
 
 ### Frontend
+
+Instala las dependencias y arranca el modo desarrollo:
+
 ```bash
 cd frontend
 npm install
@@ -68,10 +71,15 @@ npm run dev
 ```
 
 ### Backend
+
+Instala las dependencias base (y opcionalmente las de prueba) antes de ejecutar:
+
 ```bash
 cd backend
 python -m pip install --upgrade pip
 pip install -r requirements.txt
+# Dependencias opcionales para tests
+pip install -r requirements-test.txt
 python main.py
 ```
 

--- a/backend/requirements-test.txt
+++ b/backend/requirements-test.txt
@@ -5,4 +5,3 @@ python-docx>=0.8.11
 fpdf2>=2.7
 pypdf==6.0.0
 ftfy==6.2.0
-

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,13 @@
+Flask
+Flask-Cors
+Flask-JWT-Extended
+Flask-SocketIO
+Flask-SQLAlchemy
+SQLAlchemy
+Pillow
+pypdf
+python-docx
+fpdf2
+moviepy
+bcrypt
+chardet

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "anclora-metaform-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "next": "^14.2.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0",
+    "vitest": "^1.0.4"
+  }
+}


### PR DESCRIPTION
## Summary
- add backend requirements manifest with Flask, SQLAlchemy, Pillow and more
- ensure backend test requirements end with a newline
- add frontend package.json for Next/React with Tailwind and Vite scripts
- document dependency installation steps in README

## Testing
- `python -m pytest` (fails: FileNotFoundError: /home/ubuntu/test_results.json)
- `cd frontend && npm test` (fails: sh: 1: vitest: not found)

------
https://chatgpt.com/codex/tasks/task_e_68a26a09fd8c832086a057e9cf521ed3