### PR TITLE
chore: sync nexus dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,7 @@ SQLAlchemy==2.0.23
 python-docx>=0.8.11
 fpdf2>=2.7
 pypdf==6.0.0
+lxml>=4.9.3  # XML parsing for python-docx
 
 # Text processing utilities
 ftfy==6.2.0
@@ -27,6 +28,7 @@ gunicorn==21.2.0
 # Environment variables
 python-dotenv==1.0.0
 
+typing_extensions>=4.14.1  # Backports for newer typing features
 chardet==5.2.0
 bcrypt>=4.0
 

--- a/docs/nexus_migration_plan.md
+++ b/docs/nexus_migration_plan.md
@@ -6,6 +6,8 @@
 | --- | --- | --- | --- |
 | `encoding_normalizer` | `backend/src/nexus/encoding_normalizer.py` | Crítico | Núcleo de normalización de encoding; depende de `chardet`. |
 | `chardet` | Paquete externo | Crítico | Utilizado para detección automática de encoding. |
+| `lxml` | Paquete externo | Opcional | Biblioteca XML requerida por `python-docx`. |
+| `typing_extensions` | Paquete externo | Opcional | Proporciona compatibilidad con anotaciones de tipos futuras. |
 | Integración con `ConversionEngine` | `backend/src/models/conversion.py` | Crítico | Se invoca `normalize_to_utf8` antes de cada conversión de texto. |
 | CLI de normalización | `backend/src/nexus/cli.py` | Opcional | Herramienta de línea de comandos para normalizar archivos manualmente. |
 | Registro de eventos | `backend/logs/encoding/encoding_normalizer.log` | Opcional | Mantiene trazabilidad de cambios realizados. |


### PR DESCRIPTION
## Summary
- add lxml and typing_extensions from nexus requirements
- document new dependencies in migration plan

## Testing
- `pip install -r backend/requirements.txt`
- `pytest` *(fails: conversion progress and classifier tests)*

------
https://chatgpt.com/codex/tasks/task_e_68abf17e405c83209907cbca1e6acc48