### PR TITLE
Migrate encoding normalizer into main module

### DIFF
--- a/backend/src/cli.py
+++ b/backend/src/cli.py
@@ -1,0 +1,41 @@
+import argparse
+from pathlib import Path
+
+from .encoding_normalizer import detect_encoding, normalize_to_utf8, repair_mojibake, undo_normalization
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Normalize file encodings to UTF-8")
+    parser.add_argument("paths", nargs="+", help="Files to process")
+    parser.add_argument("--bom", action="store_true", help="Write UTF-8 BOM")
+    parser.add_argument("--dry-run", action="store_true", help="Preview changes without modifying files")
+    parser.add_argument("--undo", action="store_true", help="Restore files from backups")
+    args = parser.parse_args()
+
+    for path_str in args.paths:
+        path = Path(path_str)
+        if args.undo:
+            success = undo_normalization(path)
+            if success:
+                print(f"Restored {path}")
+            else:
+                print(f"No backup for {path}")
+            continue
+
+        if args.dry_run:
+            raw = path.read_bytes()
+            enc = detect_encoding(raw)
+            text = raw.decode(enc or "utf-8", errors="ignore")
+            repaired = repair_mojibake(text)
+            target = "utf-8-sig" if args.bom else "utf-8"
+            print(f"{path}: {enc} -> {target}")
+            if repaired != text:
+                print("  (mojibake repaired)")
+            continue
+
+        normalize_to_utf8(path, bom=args.bom)
+        print(f"Normalized {path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/backend/src/encoding_normalizer.py
+++ b/backend/src/encoding_normalizer.py
@@ -1,0 +1,89 @@
+import json
+import re
+from pathlib import Path
+from datetime import datetime
+
+import chardet
+
+MOJIBAKE_RE = re.compile(r"Ã|Â|â€")
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+LOG_DIR = BASE_DIR / "logs" / "encoding"
+LOG_FILE = LOG_DIR / "encoding_normalizer.log"
+
+
+def detect_encoding(raw_bytes: bytes) -> str:
+    """Detect the encoding of the given raw bytes using chardet."""
+    result = chardet.detect(raw_bytes)
+    return result.get("encoding") or "utf-8"
+
+
+def repair_mojibake(text: str) -> str:
+    """Attempt to repair common mojibake issues."""
+    if MOJIBAKE_RE.search(text):
+        try:
+            return text.encode("latin1").decode("utf-8")
+        except Exception:
+            return text
+    return text
+
+
+def _log_entry(entry: dict) -> None:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    with LOG_FILE.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+
+def normalize_to_utf8(path, bom: bool = False) -> dict:
+    """Normalize the file at ``path`` to UTF-8 encoding.
+
+    Parameters
+    ----------
+    path: str or Path
+        Path to the file to normalize.
+    bom: bool
+        If True, write a UTF-8 BOM.
+
+    Returns
+    -------
+    dict
+        The log entry describing the normalization.
+    """
+    file_path = Path(path)
+    raw = file_path.read_bytes()
+    detected = detect_encoding(raw)
+    text = raw.decode(detected or "utf-8", errors="ignore")
+    repaired = repair_mojibake(text)
+    encoded = repaired.encode("utf-8-sig" if bom else "utf-8")
+
+    backup_path = file_path.with_suffix(file_path.suffix + ".bak")
+    backup_path.write_bytes(raw)
+    file_path.write_bytes(encoded)
+
+    entry = {
+        "path": str(file_path),
+        "backup": str(backup_path),
+        "from": detected,
+        "to": "utf-8-sig" if bom else "utf-8",
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+    }
+    _log_entry(entry)
+    return entry
+
+
+def undo_normalization(path) -> bool:
+    """Restore a file from its backup if available."""
+    file_path = Path(path)
+    backup_path = file_path.with_suffix(file_path.suffix + ".bak")
+    if not backup_path.exists():
+        return False
+    original = backup_path.read_bytes()
+    file_path.write_bytes(original)
+    backup_path.unlink()
+    entry = {
+        "path": str(file_path),
+        "action": "undo",
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+    }
+    _log_entry(entry)
+    return True

--- a/backend/src/models/conversion.py
+++ b/backend/src/models/conversion.py
@@ -6,7 +6,7 @@ from collections import deque
 from pathlib import Path
 
 from src.ws import emit_progress, Phase
-from src.nexus.encoding_normalizer import normalize_to_utf8
+from src.encoding_normalizer import normalize_to_utf8
 from src.models.user import Conversion, CreditTransaction
 
 

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(parent_dir))
 
 from src.models.user import db, User
 from src.models.conversion import Conversion, CreditTransaction
-from src.nexus.encoding_normalizer import normalize_to_utf8
+from src.encoding_normalizer import normalize_to_utf8
 import tempfile
 import shutil
 

--- a/backend/tests/integration/test_normalization_flow.py
+++ b/backend/tests/integration/test_normalization_flow.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from src.models import conversion as conversion_module
-from src.nexus import encoding_normalizer
+from src import encoding_normalizer
 
 
 @pytest.mark.integration

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -12,7 +12,7 @@ parent_dir = Path(__file__).parent.parent
 sys.path.insert(0, str(parent_dir))
 
 from src.models.user import db, User, Conversion, CreditTransaction
-from src.nexus.encoding_normalizer import normalize_to_utf8
+from src.encoding_normalizer import normalize_to_utf8
 import tempfile
 import shutil
 

--- a/backend/tests/unit/test_cli.py
+++ b/backend/tests/unit/test_cli.py
@@ -6,11 +6,11 @@ BACKEND_DIR = Path(__file__).resolve().parents[2]
 
 
 def run_cli(args):
-    """Execute the nexus CLI with given arguments."""
+    """Execute the encoding CLI with given arguments."""
     env = os.environ.copy()
     env["PYTHONPATH"] = str(BACKEND_DIR / "src")
     return subprocess.run(
-        ["python", "-m", "src.nexus.cli", *args],
+        ["python", "-m", "src.cli", *args],
         cwd=str(BACKEND_DIR),
         capture_output=True,
         text=True,

--- a/backend/tests/unit/test_encoding_normalizer.py
+++ b/backend/tests/unit/test_encoding_normalizer.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from src.nexus.encoding_normalizer import (
+from src.encoding_normalizer import (
     detect_encoding,
     normalize_to_utf8,
     repair_mojibake,
@@ -25,7 +25,7 @@ def test_normalize_to_utf8(tmp_path):
     file_path.write_bytes("áéíóú".encode("utf-16"))
 
     # ensure log clean
-    log_file = Path(__file__).resolve().parents[2] / "backend/logs/encoding/encoding_normalizer.log"
+    log_file = Path(__file__).resolve().parents[2] / "logs/encoding/encoding_normalizer.log"
     if log_file.exists():
         log_file.unlink()
 

--- a/backend/tests/utils/test_imports.py
+++ b/backend/tests/utils/test_imports.py
@@ -16,7 +16,7 @@ def test_imports():
         print("✅ Modelos importados correctamente")
         
         # Test 2: Importar normalización
-        from src.nexus.encoding_normalizer import detect_encoding, normalize_to_utf8
+        from src.encoding_normalizer import detect_encoding, normalize_to_utf8
         print("✅ Módulo de normalización importado correctamente")
         
         # Test 3: Verificar chardet

--- a/docs/encoding_normalization.md
+++ b/docs/encoding_normalization.md
@@ -7,7 +7,7 @@ La normalización de encoding asegura que todos los archivos de texto se procese
 La interfaz de línea de comandos permite normalizar archivos de manera individual o en lote:
 
 ```bash
-python backend/src/nexus/cli.py <archivos>
+python backend/src/cli.py <archivos>
 ```
 
 ### Opciones disponibles
@@ -20,13 +20,13 @@ python backend/src/nexus/cli.py <archivos>
 
 ```bash
 # Normalizar archivo.txt a UTF-8
-python backend/src/nexus/cli.py archivo.txt
+python backend/src/cli.py archivo.txt
 
 # Previsualizar normalización y agregar BOM
-python backend/src/nexus/cli.py archivo.txt --dry-run --bom
+python backend/src/cli.py archivo.txt --dry-run --bom
 
 # Restaurar desde respaldo
-python backend/src/nexus/cli.py archivo.txt --undo
+python backend/src/cli.py archivo.txt --undo
 ```
 
 ## Integración con el Motor de Conversión

--- a/docs/nexus_migration_plan.md
+++ b/docs/nexus_migration_plan.md
@@ -4,12 +4,12 @@
 
 | Componente | Ubicación / Librería | Clasificación | Notas |
 | --- | --- | --- | --- |
-| `encoding_normalizer` | `backend/src/nexus/encoding_normalizer.py` | Crítico | Núcleo de normalización de encoding; depende de `chardet`. |
+| `encoding_normalizer` | `backend/src/encoding_normalizer.py` | Crítico | Núcleo de normalización de encoding; depende de `chardet`. |
 | `chardet` | Paquete externo | Crítico | Utilizado para detección automática de encoding. |
 | `lxml` | Paquete externo | Opcional | Biblioteca XML requerida por `python-docx`. |
 | `typing_extensions` | Paquete externo | Opcional | Proporciona compatibilidad con anotaciones de tipos futuras. |
 | Integración con `ConversionEngine` | `backend/src/models/conversion.py` | Crítico | Se invoca `normalize_to_utf8` antes de cada conversión de texto. |
-| CLI de normalización | `backend/src/nexus/cli.py` | Opcional | Herramienta de línea de comandos para normalizar archivos manualmente. |
+| CLI de normalización | `backend/src/cli.py` | Opcional | Herramienta de línea de comandos para normalizar archivos manualmente. |
 | Registro de eventos | `backend/logs/encoding/encoding_normalizer.log` | Opcional | Mantiene trazabilidad de cambios realizados. |
 | Reparación de *mojibake* | Función `repair_mojibake` en `encoding_normalizer.py` | Experimental | Heurística para corregir caracteres mal codificados. |
 | Reversión de normalización | Función `undo_normalization` en `encoding_normalizer.py` | Experimental | Restaura archivos desde copias de respaldo. |


### PR DESCRIPTION
## Summary
- Copy encoding normalizer and CLI into main `src` package
- Update conversion engine, tests, and docs to import `src.encoding_normalizer`
- Ensure logs remain under `backend/logs/encoding`

## Testing
- `pytest backend/tests/unit/test_encoding_normalizer.py backend/tests/unit/test_cli.py backend/tests/integration/test_normalization_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68abf46a72d0832085ca84f3f1419548