### PR TITLE
Call normalization during conversions

### DIFF
--- a/backend/src/models/conversion.py
+++ b/backend/src/models/conversion.py
@@ -174,19 +174,25 @@ class ConversionEngine:
         """Realiza la conversión de archivo"""
         try:
             source = source_format.lower().replace('.', '')
+            logs = []
+
             if source in TEXT_EXTENSIONS:
-                normalize_to_utf8(input_path)
+                log_entry = normalize_to_utf8(input_path)
+                logs.append(
+                    f"normalized:{log_entry.get('from')}->{log_entry.get('to')}"
+                )
 
             target = target_format.lower()
             method = self.conversion_methods.get((source, target))
             if method:
-                return method(input_path, output_path)
+                success, msg = method(input_path, output_path)
+                logs.append(f"{source}->{target}: {msg}")
+                return success, " | ".join(logs)
 
             path = self.find_conversion_path(source, target)
             if not path:
                 return False, f"Conversión {source_format} → {target_format} no implementada aún"
 
-            logs = []
             temp_files = []
             current_input = input_path
 
@@ -199,7 +205,10 @@ class ConversionEngine:
                         return False, f"Conversión {src_fmt} → {dst_fmt} no implementada"
 
                     if src_fmt in TEXT_EXTENSIONS:
-                        normalize_to_utf8(current_input)
+                        log_entry = normalize_to_utf8(current_input)
+                        logs.append(
+                            f"normalized:{log_entry.get('from')}->{log_entry.get('to')}"
+                        )
 
                     if i == len(path) - 2:
                         current_output = output_path

--- a/backend/tests/integration/test_normalization_integration.py
+++ b/backend/tests/integration/test_normalization_integration.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+import chardet
+from src.models.conversion import conversion_engine
+
+
+def test_text_file_normalized_before_conversion(tmp_path):
+    content = "áéíóú"
+    input_path = tmp_path / "sample.txt"
+    input_path.write_bytes(content.encode("latin-1"))
+    output_path = tmp_path / "sample.html"
+
+    success, _ = conversion_engine.convert_file(
+        str(input_path), str(output_path), "txt", "html"
+    )
+
+    assert success
+    # Ensure backup created by normalizer exists
+    backup_path = tmp_path / "sample.txt.bak"
+    assert backup_path.exists()
+
+    # Verify file has been normalized to UTF-8
+    raw = input_path.read_bytes()
+    detected = chardet.detect(raw).get("encoding", "").lower()
+    assert detected.startswith("utf")

--- a/backend/tests/unit/test_normalization.py
+++ b/backend/tests/unit/test_normalization.py
@@ -1,0 +1,28 @@
+import os
+import tempfile
+from src.models.conversion import conversion_engine
+
+
+def test_convert_file_invokes_normalizer(monkeypatch):
+    calls = []
+
+    def fake_normalize(path, bom=False):
+        calls.append(path)
+        return {"from": "latin-1", "to": "utf-8"}
+
+    monkeypatch.setattr(
+        "src.models.conversion.normalize_to_utf8", fake_normalize
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        input_path = os.path.join(tmp, "in.txt")
+        with open(input_path, "w", encoding="utf-8") as fh:
+            fh.write("hola")
+        output_path = os.path.join(tmp, "out.pdf")
+        success, msg = conversion_engine.convert_file(
+            input_path, output_path, "txt", "pdf"
+        )
+
+        assert success
+        assert calls and calls[0] == input_path
+        assert "normalized:latin-1->utf-8" in msg


### PR DESCRIPTION
## Summary
- Call UTF-8 normalizer before performing conversions and log normalization steps
- Add unit and integration tests to verify normalization occurs prior to conversion

## Testing
- `pytest`
- `pytest tests/unit/test_normalization.py tests/integration/test_normalization_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68abfa96c54c832099aa797534a3c2bb