### PR TITLE
feat: add observability logging and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ cd backend
 python -m pip install --upgrade pip
 pip install -r requirements.txt
 python main.py
+
+La API expondrá un endpoint de métricas en `http://localhost:8000/metrics` y mostrará logs según el nivel definido.
 ```
 
 ### Variables de entorno (Backend)
@@ -83,6 +85,7 @@ Antes de ejecutar el backend, configura las siguientes variables de entorno:
 - `JWT_SECRET_KEY`: clave para firmar tokens JWT.
 - `ALLOWED_ORIGINS`: lista separada por comas de orígenes permitidos para CORS (ej. `http://localhost:3000,http://localhost:5173`). El comodín `*` se ignora por seguridad.
 - `FLASK_DEBUG`: establece `true` para habilitar el modo debug (opcional).
+- `LOG_LEVEL`: nivel de logs (`DEBUG`, `INFO`, `WARNING`, etc.). Opcional, por defecto `INFO`.
 
 ### Ejecutar Tests
 ```bash
@@ -166,7 +169,7 @@ npm run test:all
 ## 📈 Monitoreo y Logs
 
 - Logging estructurado
-- Métricas de uso
+- Métricas de uso expuestas en `/metrics`
 - Monitoring de performance
 - Error tracking
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -32,3 +32,6 @@ typing_extensions>=4.14.1  # Backports for newer typing features
 chardet==5.2.0
 bcrypt>=4.0
 
+# Metrics
+prometheus-flask-exporter==0.23.2
+

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -3,9 +3,11 @@ import sys
 # DON'T CHANGE THIS !!!
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from flask import Flask, send_from_directory, jsonify
+from flask import Flask, send_from_directory, jsonify, request
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
+from prometheus_flask_exporter import PrometheusMetrics
+import logging
 from src.models.user import db
 from src.routes.user import user_bp
 from src.routes.auth import auth_bp
@@ -15,6 +17,13 @@ from datetime import timedelta
 from src.ws import socketio
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
+
+# Configuración de logging
+log_level = os.environ.get('LOG_LEVEL', 'INFO').upper()
+logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
+logging.getLogger('werkzeug').setLevel(logging.WARNING)
+metrics = PrometheusMetrics(app)
+metrics.info('app_info', 'Anclora Metaform API', version='1.0.0')
 
 # Configuración de seguridad
 secret_key = os.environ.get('SECRET_KEY')
@@ -68,6 +77,16 @@ app.register_blueprint(credits_bp, url_prefix='/api/credits')
 # Crear tablas de base de datos
 with app.app_context():
     db.create_all()
+
+# Registro de solicitudes
+@app.before_request
+def log_request():
+    app.logger.info("%s %s", request.method, request.path)
+
+@app.after_request
+def log_response(response):
+    app.logger.info("%s %s -> %s", request.method, request.path, response.status_code)
+    return response
 
 # Manejador de errores JWT
 @jwt.expired_token_loader

--- a/docs/INSTALACION.md
+++ b/docs/INSTALACION.md
@@ -154,6 +154,17 @@ npm install --save-dev @types/jszip
 3. **Formatos:** Todos los formatos generados son estándar y compatibles con software común
 4. **Rendimiento:** Las conversiones son instantáneas para archivos de texto típicos
 
+## 📈 Métricas y Logs
+
+Una vez integrado el backend, instala también las dependencias de observabilidad:
+
+```bash
+cd backend
+pip install -r requirements.txt
+```
+
+Define el nivel de logging con la variable de entorno `LOG_LEVEL` y consulta las métricas en `http://localhost:8000/metrics`.
+
 ## 🎉 ¡Listo!
 
 Una vez completada la instalación, tu Anclora Converter tendrá:

--- a/docs/QUICK_START_GUIDE.md
+++ b/docs/QUICK_START_GUIDE.md
@@ -83,6 +83,7 @@ Con este repositorio, **Anclora Metaform** tiene:
 - ✅ **Calidad profesional** en todas las conversiones
 - ✅ **Base sólida** para futuras funcionalidades
 - ✅ **Todo sincronizado** y listo para producción
+- ✅ **Observabilidad integrada**: logs configurables y métricas en `/metrics`
 
 ## 🆘 ¿Necesitas Ayuda?
 

--- a/docs/module_interactions.md
+++ b/docs/module_interactions.md
@@ -16,4 +16,8 @@ This document summarizes how newly added e‑book conversion modules integrate w
 - The e‑book modules interact with existing authentication and credit systems without requiring schema changes.
 - Both converters emit progress updates over the same WebSocket channel, allowing the frontend to monitor status uniformly.
 
+## Observability
+- A new metrics module exposes Prometheus data at `/metrics`, integrating with existing services without altering API contracts.
+- Centralized request logging reuses Flask's logging system, so authentication and conversion modules emit uniform logs.
+
 These interactions were reviewed after integration to verify that legacy functionality continues to operate alongside the new e‑book features.


### PR DESCRIPTION
## Summary
- add Prometheus metrics and request logging
- document observability and LOG_LEVEL in installation and usage guides
- describe monitoring modules in module interactions docs

## Testing
- `python -m pytest` *(fails: AssertionError and 404s in conversion tests)*

------
https://chatgpt.com/codex/tasks/task_e_68abfd7fce688320a65697974860d1ff