### PR TITLE
Add post-merge test workflow and rollback guide

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,7 +1,7 @@
-name: test
+name: test-main
 
 on:
-  pull_request:
+  push:
     branches: [ main ]
 
 jobs:

--- a/docs/REVERT_PRE_NEXUS_MIGRATION.md
+++ b/docs/REVERT_PRE_NEXUS_MIGRATION.md
@@ -1,0 +1,33 @@
+# Revertir al tag `pre-nexus-migration`
+
+En caso de que la migración a Nexus falle, puedes volver rápidamente al estado previo usando el tag `pre-nexus-migration`.
+
+## Pasos
+
+1. Guarda los cambios actuales (opcional):
+   ```bash
+   git status
+   git stash -u
+   ```
+2. Obtén la información más reciente del repositorio y los tags:
+   ```bash
+   git fetch --all --tags
+   ```
+3. Vuelve a la rama `main` y resetea su estado al tag:
+   ```bash
+   git checkout main
+   git reset --hard pre-nexus-migration
+   ```
+4. Sube el cambio al repositorio remoto:
+   ```bash
+   git push origin main --force
+   ```
+
+> ⚠️ **Advertencia:** El uso de `--force` reescribe el historial de la rama `main`. Asegúrate de coordinar este paso con el equipo.
+
+5. Recupera los cambios locales guardados (si se usó `stash`):
+   ```bash
+   git stash pop
+   ```
+
+Tras estos pasos, el proyecto quedará exactamente en el estado anterior a la migración.


### PR DESCRIPTION
## Summary
- run backend and frontend tests automatically on pushes to `main`
- separate pull request and post-merge workflows
- document steps to revert to `pre-nexus-migration` tag

## Testing
- `pytest -q` *(fails: 9 failed, 71 passed)*
- `npm run test:a11y` *(fails: Could not resolve "vitest.a11y.config.ts")*


------
https://chatgpt.com/codex/tasks/task_e_68abfd9121e083208a489aea356aef68