### PR TITLE
Add encoding coverage tests

### DIFF
--- a/backend/tests/integration/test_conversion_flow_encodings.py
+++ b/backend/tests/integration/test_conversion_flow_encodings.py
@@ -1,0 +1,45 @@
+import io
+from pathlib import Path
+
+import pytest
+
+from src.models import conversion as conversion_module
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("encoding", ["latin1", "utf-16"])
+def test_full_conversion_flow_multiple_encodings(client, auth_headers, monkeypatch, encoding):
+    """Ensure uploads with various encodings are normalized and converted."""
+    calls = []
+    original = conversion_module.normalize_to_utf8
+
+    def tracker(path):
+        calls.append(path)
+        return original(path)
+
+    monkeypatch.setattr(conversion_module, "normalize_to_utf8", tracker)
+
+    content = "áéíóú".encode(encoding)
+    data = {
+        "file": (io.BytesIO(content), "acentos.txt"),
+        "target_format": "html",
+    }
+
+    resp = client.post(
+        "/api/conversion/convert",
+        data=data,
+        headers=auth_headers,
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 200
+    assert len(calls) == 1
+    bak_path = Path(calls[0]).with_suffix(Path(calls[0]).suffix + ".bak")
+    assert bak_path.exists()
+
+    conversion_id = resp.get_json()["conversion"]["id"]
+    download_resp = client.get(
+        f"/api/conversion/download/{conversion_id}", headers=auth_headers
+    )
+    assert download_resp.status_code == 200
+    download_resp.data.decode("utf-8")
+

--- a/backend/tests/unit/test_encoding_normalizer.py
+++ b/backend/tests/unit/test_encoding_normalizer.py
@@ -33,6 +33,41 @@ def test_normalize_to_utf8(tmp_path):
     assert file_path.read_text(encoding="utf-8") == "áéíóú"
     assert Path(entry["backup"]).exists()
 
+
     with log_file.open() as fh:
         last = json.loads(fh.readlines()[-1])
     assert last["path"] == str(file_path)
+
+
+@pytest.mark.parametrize(
+    "encoding,text,expected_substring",
+    [
+        ("utf-16", "áéíóú", "utf-16"),
+        ("latin1", "canción número", "iso-8859"),
+        ("utf-8-sig", "hola", "utf-8"),
+    ],
+)
+def test_detect_encoding_multiple(encoding, text, expected_substring):
+    """Detects several common encodings."""
+    sample = text.encode(encoding)
+    detected = detect_encoding(sample).lower()
+    assert expected_substring in detected
+
+
+@pytest.mark.parametrize(
+    "encoding,text",
+    [
+        ("utf-16", "áéíóú"),
+        ("latin1", "canción número"),
+        ("utf-8-sig", "hola"),
+    ],
+)
+def test_normalize_to_utf8_multiple(tmp_path, encoding, text):
+    """Normalizes files from multiple encodings to UTF-8."""
+    file_path = tmp_path / f"sample_{encoding}.txt"
+    file_path.write_bytes(text.encode(encoding))
+
+    entry = normalize_to_utf8(file_path)
+    assert file_path.read_text(encoding="utf-8") == text
+    assert Path(entry["backup"]).exists()
+


### PR DESCRIPTION
## Summary
- add parametrized unit tests for multiple encodings in encoding normalizer
- cover full conversion flows for latin1 and UTF-16 uploads

## Testing
- `pytest --cov=src --cov-report=term` *(fails: tests/integration/test_conversion_progress.py::TestConversionProgress::test_conversion_status_updates, tests/integration/test_conversion_progress.py::TestConversionProgress::test_conversion_history, tests/integration/test_conversion_undo.py::TestConversionUndo::test_undo_conversion_refunds_credits, tests/unit/test_conversion_classifier.py::test_validate_and_classify_valid, tests/unit/test_conversion_classifier.py::test_validate_and_classify_mojibake, tests/unit/test_conversion_classifier.py::test_validate_and_classify_corrupt, tests/unit/test_conversion_engine.py::test_conversion_engine[docx-pdf], tests/unit/test_conversion_engine[docx-txt], tests/unit/test_conversion_engine[docx-html])* 
- `pytest tests/unit/test_encoding_normalizer.py -k "detect_encoding_multiple or normalize_to_utf8_multiple" -vv`
- `pytest tests/integration/test_conversion_flow_encodings.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68ac00d806408320a42804f73716a77e