### PR TITLE
docs: update module setup instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todos los cambios notables de este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-08-25
+
+### 📚 Documentación
+- Añadidas guías de dependencias e instalación para frontend y backend
+- README actualizado para frontend y nuevo README para backend
+
 ## [1.0.0] - 2024-07-16
 
 ### 🎉 Lanzamiento Inicial

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,28 @@
+# 🛠️ Anclora Metaform - Backend
+
+## Requisitos
+- Python 3.10+
+- pip
+
+## Dependencias clave
+- Flask y extensiones (`Flask-CORS`, `Flask-JWT-Extended`, `Flask-SQLAlchemy`)
+- Librerías de documentos (`python-docx`, `fpdf2`, `pypdf`, `lxml`)
+- `prometheus-flask-exporter` para métricas
+
+## Instalación
+```bash
+cd backend
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+## Uso
+```bash
+python src/main.py
+```
+El servicio quedará disponible en `http://localhost:8000/api` con métricas en `http://localhost:8000/metrics`.
+
+## Pruebas
+```bash
+python -m pytest tests/
+```

--- a/docs/DEPENDENCIAS_INSTALACION.md
+++ b/docs/DEPENDENCIAS_INSTALACION.md
@@ -1,0 +1,41 @@
+# 📦 Dependencias e Instalación
+
+Este documento resume las dependencias clave, pasos de instalación y ejemplos de uso para los módulos principales de **Anclora Metaform**.
+
+## 🖥️ Frontend
+
+### Dependencias principales
+- Node.js 18+
+- [open-cli](https://github.com/sindresorhus/open-cli) para abrir el navegador automáticamente
+- [Vitest](https://vitest.dev/) para pruebas
+- Librerías de conversión: `docx`, `jszip`
+
+### Instalación
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+### Ejemplo de uso
+Visita `http://localhost:5173`, carga un archivo de texto y selecciona el formato de salida (HTML, DOC, MD, RTF, ODT o TEX).
+
+## 🛠️ Backend
+
+### Dependencias principales
+- Python 3.10+
+- [Flask](https://flask.palletsprojects.com/) y extensiones: `Flask-CORS`, `Flask-JWT-Extended`, `Flask-SQLAlchemy`
+- Librerías de documentos: `python-docx`, `fpdf2`, `pypdf`, `lxml`
+- Observabilidad: `prometheus-flask-exporter`
+
+### Instalación
+```bash
+cd backend
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+python src/main.py
+```
+
+### Ejemplo de uso
+Envía un `POST` a `http://localhost:8000/api/conversion` con un archivo TXT y recibe el documento convertido en el formato solicitado.
+

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,21 +1,26 @@
-# 📦 Anclora Metaform - Paquete de Integración
+# 🎨 Anclora Metaform - Frontend
 
-![Anclora Metaform Logo](./src/assets/anclora_metaform_logo.png)
+## Requisitos
+- Node.js 18+
+- npm o yarn
 
-**Tu Contenido, Reinventado**
+## Instalación
+```bash
+cd frontend
+npm install
+```
 
-## 📚 Resumen
-Este paquete contiene **6 nuevos conversores** que expanden las capacidades de Anclora Metaform, logrando **paridad competitiva completa** con las principales herramientas del mercado.
+## Uso
+```bash
+npm run dev
+```
+El navegador se abrirá automáticamente en `http://localhost:5173` gracias a **open-cli**.
 
-...
+## Dependencias clave
+- `open-cli`: apertura automática del navegador
+- `docx` y `jszip`: conversores de documentos
+- `vitest`: suite de pruebas
 
-## 📜 Scripts de desarrollo
-
-- `npm run dev`: inicia Next.js en modo desarrollo y abre el navegador predeterminado mediante [open-cli](https://github.com/sindresorhus/open-cli), funcionando en Windows, macOS y Linux.
-- `npm test`: ejecuta la suite de pruebas con [Vitest](https://vitest.dev/).
-
-**🎯 Misión Cumplida:** Paridad competitiva completa lograda  
-**🗓️ Fecha:** Julio 2023  
-**✅ Estado:** Listo para producción
-
-*Powered by **Anclora Metaform** - Tu Contenido, Reinventado*
+## Scripts disponibles
+- `npm run dev`: inicia la aplicación en modo desarrollo
+- `npm test`: ejecuta la suite de pruebas


### PR DESCRIPTION
## Summary
- document frontend and backend dependencies with installation and usage examples
- add dedicated backend README
- refresh changelog with documentation updates

## Testing
- `python -m pytest tests/` *(fails: 9 failed, 79 passed)*
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ac03821898832085d339c5c17f6eeb